### PR TITLE
elasticsearch: Add `pkg/espoll`, `cmd/espoll`

### DIFF
--- a/cmd/espoll/main.go
+++ b/cmd/espoll/main.go
@@ -1,0 +1,148 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"time"
+
+	"github.com/elastic/apm-tool/pkg/espoll"
+	"github.com/elastic/go-elasticsearch/v8"
+)
+
+const (
+	adminElasticsearchUser  = "admin"
+	adminElasticsearchPass  = "changeme"
+	maxElasticsearchBackoff = 10 * time.Second
+)
+
+type config struct {
+	query      string
+	esURL      string
+	esUsername string
+	esPassword string
+
+	target  string
+	timeout time.Duration
+	hits    uint
+}
+
+func main() {
+	var cfg config
+	flag.StringVar(&cfg.query, "query", "", "The Elasticsearch query in Query DSL. Must be set via this flag or stdin.")
+	flag.StringVar(&cfg.target, "target", "traces-*,logs-*,metrics-*",
+		"Comma-separated list of data streams, indices, and aliases to search (Supports wildcards (*)).",
+	)
+	flag.DurationVar(&cfg.timeout, "timeout", 30*time.Second,
+		"Elasticsearch request timeout",
+	)
+	flag.UintVar(&cfg.hits, "min-hits", 1,
+		"When specified and > 10, this should cause the size parameter to be set.",
+	)
+
+	// Elasticsearch
+	flag.StringVar(&cfg.esUsername, "elasticsearch-user", adminElasticsearchUser,
+		"Elasticsearch username.",
+	)
+	flag.StringVar(&cfg.esPassword, "elasticsearch-pass", adminElasticsearchPass,
+		"Elasticsearch password.",
+	)
+	flag.StringVar(&cfg.esURL, "elasticsearch-url", os.Getenv("ELASTICSEARCH_URL"),
+		"Elasticsearch password.",
+	)
+	flag.Parse()
+
+	if cfg.query == "" {
+		stat, err := os.Stdin.Stat()
+		if err != nil {
+			log.Fatalf("failed to stat stdin: %s", err.Error())
+		}
+		if stat.Size() == 0 {
+			log.Fatal("empty -query flag and stdin, please set one.")
+		}
+		b, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			log.Fatalf("failed to read stdin: %s", err.Error())
+		}
+		cfg.query = string(strings.Trim(string(b), "\n"))
+	}
+
+	log.Println("query:", cfg.query)
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
+	defer cancel()
+
+	if err := Main(ctx, cfg); err != nil {
+		log.Fatalf("ERROR: %s", err.Error())
+	}
+}
+
+func Main(ctx context.Context, cfg config) error {
+	if cfg.query == "" {
+		return errors.New("query cannot be empty")
+	}
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+
+	client, err := elasticsearch.NewClient(elasticsearch.Config{
+		Username:   cfg.esUsername,
+		Password:   cfg.esPassword,
+		Addresses:  strings.Split(cfg.esURL, ","),
+		Transport:  transport,
+		MaxRetries: 5,
+		RetryBackoff: func(attempt int) time.Duration {
+			backoff := (500 * time.Millisecond) * (1 << (attempt - 1))
+			if backoff > maxElasticsearchBackoff {
+				backoff = maxElasticsearchBackoff
+			}
+			return backoff
+		},
+	})
+	if err != nil {
+		return err
+	}
+	esClient := espoll.WrapClient(client)
+	result, err := esClient.SearchIndexMinDocs(ctx,
+		int(cfg.hits), cfg.target, stringMarshaler(cfg.query),
+		espoll.WithTimeout(cfg.timeout),
+	)
+	if err != nil {
+		return fmt.Errorf("search request returned error: %w", err)
+	}
+
+	if err := json.NewEncoder(os.Stdout).Encode(result); err != nil {
+		return fmt.Errorf("failed to encode search result: %w", err)
+	}
+	return nil
+}
+
+type stringMarshaler string
+
+func (s stringMarshaler) MarshalJSON() ([]byte, error) { return []byte(s), nil }

--- a/pkg/espoll/client.go
+++ b/pkg/espoll/client.go
@@ -1,0 +1,170 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package espoll wraps an elasticsearch.Client to provide utilitarian methods
+// to assert for conditions until a certain threshold is met.
+package espoll
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"time"
+
+	"github.com/elastic/go-elasticsearch/v8"
+	"github.com/elastic/go-elasticsearch/v8/esapi"
+)
+
+// Client wraps an Elasticsearch client
+type Client struct {
+	*elasticsearch.Client
+}
+
+// WrapClient wraps an Elasticsearch client and returns an espoll.Client
+func WrapClient(c *elasticsearch.Client) *Client { return &Client{Client: c} }
+
+type Request interface {
+	Do(ctx context.Context, transport esapi.Transport) (*esapi.Response, error)
+}
+
+// Do performs the specified request.
+func (es *Client) Do(
+	ctx context.Context,
+	req Request,
+	out any,
+	opts ...RequestOption,
+) (*esapi.Response, error) {
+	requestOptions := requestOptions{
+		// Set the timeout to something high to account for Elasticsearch
+		// cluster and index/shard initialisation. Under normal conditions
+		// this timeout should never be reached.
+		timeout:  time.Minute,
+		interval: 100 * time.Millisecond,
+	}
+	for _, opt := range opts {
+		opt(&requestOptions)
+	}
+	var timeoutC, tickerC <-chan time.Time
+	var transport esapi.Transport = es
+	if requestOptions.cond != nil {
+		// A return condition has been specified, which means we
+		// might retry the request. Wrap the transport with a
+		// bodyRepeater to ensure the body is copied as needed.
+		transport = &bodyRepeater{transport, nil}
+		if requestOptions.timeout > 0 {
+			timeout := time.NewTimer(requestOptions.timeout)
+			defer timeout.Stop()
+			timeoutC = timeout.C
+		}
+	}
+
+	var resp *esapi.Response
+	for {
+		if tickerC != nil {
+			select {
+			case <-timeoutC:
+				return nil, context.DeadlineExceeded
+			case <-tickerC:
+			}
+		}
+		var err error
+		resp, err = req.Do(ctx, transport)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+		if resp.IsError() {
+			return nil, &Error{StatusCode: resp.StatusCode, Message: resp.String()}
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		if out != nil {
+			if err := json.Unmarshal(body, out); err != nil {
+				return nil, err
+			}
+		}
+		resp.Body = io.NopCloser(bytes.NewReader(body))
+		if requestOptions.cond == nil || requestOptions.cond(resp) {
+			break
+		}
+		if tickerC == nil {
+			// First time around, start a ticker for retrying.
+			ticker := time.NewTicker(requestOptions.interval)
+			defer ticker.Stop()
+			tickerC = ticker.C
+		}
+	}
+	return resp, nil
+}
+
+// RequestOption modifies certain parameters for an esapi.Request.
+type RequestOption func(*requestOptions)
+
+type Error struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *Error) Error() string {
+	return e.Message
+}
+
+type requestOptions struct {
+	timeout  time.Duration
+	interval time.Duration
+	cond     ConditionFunc
+}
+
+// WithTimeout sets the timeout in an Elasticsearch request.
+func WithTimeout(d time.Duration) RequestOption {
+	return func(opts *requestOptions) {
+		opts.timeout = d
+	}
+}
+
+// WithInterval sets the poll interval in an Elasticsearch request.
+func WithInterval(d time.Duration) RequestOption {
+	return func(opts *requestOptions) {
+		opts.interval = d
+	}
+}
+
+// ConditionFunc evaluates the esapi.Response.
+type ConditionFunc func(*esapi.Response) bool
+
+// AllCondition returns a ConditionFunc that returns true as
+// long as none of the supplied conditions returns false.
+func AllCondition(conds ...ConditionFunc) ConditionFunc {
+	return func(resp *esapi.Response) bool {
+		for _, cond := range conds {
+			if !cond(resp) {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+// WithCondition runs the specified condition func.
+func WithCondition(cond ConditionFunc) RequestOption {
+	return func(opts *requestOptions) {
+		opts.cond = cond
+	}
+}

--- a/pkg/espoll/query.go
+++ b/pkg/espoll/query.go
@@ -1,0 +1,99 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package espoll
+
+import "encoding/json"
+
+type BoolQuery struct {
+	Filter             []any
+	Must               []any
+	MustNot            []any
+	Should             []any
+	MinimumShouldMatch int
+	Boost              float64
+}
+
+func (q BoolQuery) MarshalJSON() ([]byte, error) {
+	type boolQuery struct {
+		Filter             []any   `json:"filter,omitempty"`
+		Must               []any   `json:"must,omitempty"`
+		MustNot            []any   `json:"must_not,omitempty"`
+		Should             []any   `json:"should,omitempty"`
+		MinimumShouldMatch int     `json:"minimum_should_match,omitempty"`
+		Boost              float64 `json:"boost,omitempty"`
+	}
+	return encodeQueryJSON("bool", boolQuery(q))
+}
+
+type ExistsQuery struct {
+	Field string
+}
+
+func (q ExistsQuery) MarshalJSON() ([]byte, error) {
+	return encodeQueryJSON("exists", map[string]any{
+		"field": q.Field,
+	})
+}
+
+type TermQuery struct {
+	Field string
+	Value any
+	Boost float64
+}
+
+func (q TermQuery) MarshalJSON() ([]byte, error) {
+	type termQuery struct {
+		Value any     `json:"value"`
+		Boost float64 `json:"boost,omitempty"`
+	}
+	return encodeQueryJSON("term", map[string]any{
+		q.Field: termQuery{q.Value, q.Boost},
+	})
+}
+
+type TermsQuery struct {
+	Field  string
+	Values []any
+	Boost  float64
+}
+
+func (q TermsQuery) MarshalJSON() ([]byte, error) {
+	args := map[string]any{
+		q.Field: q.Values,
+	}
+	if q.Boost != 0 {
+		args["boost"] = q.Boost
+	}
+	return encodeQueryJSON("terms", args)
+}
+
+type MatchPhraseQuery struct {
+	Field string
+	Value any
+}
+
+func (q MatchPhraseQuery) MarshalJSON() ([]byte, error) {
+	return encodeQueryJSON("match_phrase", map[string]any{
+		q.Field: q.Value,
+	})
+}
+
+func encodeQueryJSON(k string, v any) ([]byte, error) {
+	m := map[string]any{k: v}
+	return json.Marshal(m)
+}

--- a/pkg/espoll/request.go
+++ b/pkg/espoll/request.go
@@ -1,0 +1,72 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package espoll
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+
+	"github.com/elastic/go-elasticsearch/v8/esapi"
+)
+
+// bodyRepeater wraps an esapi.Transport, copying the request body on the first
+// call to Perform as needed, and replacing the request body on subsequent calls.
+type bodyRepeater struct {
+	t       esapi.Transport
+	getBody func() (io.ReadCloser, error)
+}
+
+func (br *bodyRepeater) Perform(req *http.Request) (*http.Response, error) {
+	if req.Body == nil {
+		return br.t.Perform(req)
+	}
+	if br.getBody == nil {
+		// First call to Perform: set br.getBody to req.GetBody
+		// (if non-nil), or otherwise by replacing req.Body with
+		// a TeeReader that reads into a buffer, and setting
+		// getBody to a function that returns that buffer on
+		// subsequent calls.
+		br.getBody = req.GetBody
+		if br.getBody == nil {
+			// no GetBody, gotta copy it ourselves
+			var buf bytes.Buffer
+			req.Body = readCloser{
+				Reader: io.TeeReader(req.Body, &buf),
+				Closer: req.Body,
+			}
+			br.getBody = func() (io.ReadCloser, error) {
+				r := bytes.NewReader(buf.Bytes())
+				return io.NopCloser(r), nil
+			}
+		}
+	} else {
+		body, err := br.getBody()
+		if err != nil {
+			return nil, err
+		}
+		req.Body.Close()
+		req.Body = body
+	}
+	return br.t.Perform(req)
+}
+
+type readCloser struct {
+	io.Reader
+	io.Closer
+}

--- a/pkg/espoll/search.go
+++ b/pkg/espoll/search.go
@@ -1,0 +1,185 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package espoll
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/elastic/go-elasticsearch/v8/esapi"
+	"github.com/elastic/go-elasticsearch/v8/esutil"
+)
+
+// SearchIndexMinDocs searches index with query, returning the results.
+//
+// If the search returns fewer than min results within 10 seconds
+// (by default), SearchIndexMinDocs will return an error.
+func (es *Client) SearchIndexMinDocs(
+	ctx context.Context,
+	min int, index string,
+	query json.Marshaler,
+	opts ...RequestOption,
+) (SearchResult, error) {
+	var result SearchResult
+	req := es.NewSearchRequest(index)
+	req.ExpandWildcards = "open,hidden"
+	if min > 10 {
+		// Size defaults to 10. If the caller expects more than 10,
+		// return it in the search so we don't have to search again.
+		req = req.WithSize(min)
+	}
+	if query != nil {
+		req = req.WithQuery(query)
+	}
+	opts = append(opts, WithCondition(AllCondition(
+		result.Hits.MinHitsCondition(min),
+		result.Hits.TotalHitsCondition(req),
+	)))
+
+	// Refresh the indices before issuing the search request.
+	refreshReq := esapi.IndicesRefreshRequest{
+		Index:           strings.Split(",", index),
+		ExpandWildcards: "all",
+	}
+	rsp, err := refreshReq.Do(ctx, es.Transport)
+	if err != nil {
+		return result, fmt.Errorf("failed refreshing indices: %s: %w", index, err)
+	}
+
+	rsp.Body.Close()
+
+	if _, err := req.Do(ctx, &result, opts...); err != nil {
+		return result, fmt.Errorf("failed issuing request: %w", err)
+	}
+	return result, nil
+}
+
+// NewSearchRequest returns a search request using the wrapped Elasticsearch
+// client.
+func (es *Client) NewSearchRequest(index string) *SearchRequest {
+	req := &SearchRequest{es: es}
+	req.Index = strings.Split(index, ",")
+	req.Body = strings.NewReader(`{"fields": ["*"]}`)
+	return req
+}
+
+// SearchRequest wraps an esapi.SearchRequest with a Client.
+type SearchRequest struct {
+	esapi.SearchRequest
+	es *Client
+}
+
+func (r *SearchRequest) WithQuery(q any) *SearchRequest {
+	var body struct {
+		Query  any      `json:"query"`
+		Fields []string `json:"fields"`
+	}
+	body.Query = q
+	body.Fields = []string{"*"}
+	r.Body = esutil.NewJSONReader(&body)
+	return r
+}
+
+func (r *SearchRequest) WithSort(fieldDirection ...string) *SearchRequest {
+	r.Sort = fieldDirection
+	return r
+}
+
+func (r *SearchRequest) WithSize(size int) *SearchRequest {
+	r.Size = &size
+	return r
+}
+
+func (r *SearchRequest) Do(ctx context.Context, out *SearchResult, opts ...RequestOption) (*esapi.Response, error) {
+	return r.es.Do(ctx, &r.SearchRequest, out, opts...)
+}
+
+type SearchResult struct {
+	Hits         SearchHits                 `json:"hits"`
+	Aggregations map[string]json.RawMessage `json:"aggregations"`
+}
+
+type SearchHits struct {
+	Total SearchHitsTotal `json:"total"`
+	Hits  []SearchHit     `json:"hits"`
+}
+
+type SearchHitsTotal struct {
+	Value    int    `json:"value"`
+	Relation string `json:"relation"` // "eq" or "gte"
+}
+
+// NonEmptyCondition returns a ConditionFunc which will return true if h.Hits is non-empty.
+func (h *SearchHits) NonEmptyCondition() ConditionFunc {
+	return h.MinHitsCondition(1)
+}
+
+// MinHitsCondition returns a ConditionFunc which will return true if the number of h.Hits
+// is at least min.
+func (h *SearchHits) MinHitsCondition(min int) ConditionFunc {
+	return func(*esapi.Response) bool { return len(h.Hits) >= min }
+}
+
+// TotalHitsCondition returns a ConditionFunc which will return true if the number of h.Hits
+// is at least h.Total.Value. If the condition returns false, it will update req.Size to
+// accommodate the number of hits in the following search.
+func (h *SearchHits) TotalHitsCondition(req *SearchRequest) ConditionFunc {
+	return func(*esapi.Response) bool {
+		if len(h.Hits) >= h.Total.Value {
+			return true
+		}
+		size := h.Total.Value
+		req.Size = &size
+		return false
+	}
+}
+
+type SearchHit struct {
+	Index     string
+	ID        string
+	Score     float64
+	Fields    map[string][]any
+	Source    map[string]any
+	RawSource json.RawMessage
+}
+
+func (h *SearchHit) UnmarshalJSON(data []byte) error {
+	var searchHit struct {
+		Index  string           `json:"_index"`
+		ID     string           `json:"_id"`
+		Score  float64          `json:"_score"`
+		Source json.RawMessage  `json:"_source"`
+		Fields map[string][]any `json:"fields"`
+	}
+	if err := json.Unmarshal(data, &searchHit); err != nil {
+		return err
+	}
+	h.Index = searchHit.Index
+	h.ID = searchHit.ID
+	h.Score = searchHit.Score
+	h.RawSource = searchHit.Source
+	h.Fields = searchHit.Fields
+	h.Source = make(map[string]any)
+	return json.Unmarshal(h.RawSource, &h.Source)
+}
+
+func (h *SearchHit) UnmarshalSource(out any) error {
+	return json.Unmarshal(h.RawSource, out)
+}


### PR DESCRIPTION
Adds a new `pkg/espoll` package containing a slightly modified version of `apm-server/systemtest/estest`, and `cmd/espoll` command, allowing users to assert that a minimum number of Elasticsearch documents that match the specified query are found.