### PR TITLE
add `--insecure` flag to main command

### DIFF
--- a/cmd/apmtool/espoll.go
+++ b/cmd/apmtool/espoll.go
@@ -45,6 +45,8 @@ type config struct {
 	esUsername string
 	esPassword string
 
+	tlsSkipVerify bool
+
 	target  string
 	timeout time.Duration
 	hits    uint
@@ -56,6 +58,8 @@ func (cmd *Commands) pollDocs(c *cli.Context) error {
 		esURL:      cmd.cfg.ElasticsearchURL,
 		esUsername: cmd.cfg.Username,
 		esPassword: cmd.cfg.Password,
+
+		tlsSkipVerify: cmd.cfg.TLSSkipVerify,
 
 		target:  c.String("target"),
 		timeout: c.Duration("timeout"),
@@ -126,7 +130,7 @@ func Main(ctx context.Context, cfg config) error {
 	}
 
 	transport := http.DefaultTransport.(*http.Transport).Clone()
-	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: cfg.tlsSkipVerify}
 
 	client, err := elasticsearch.NewClient(elasticsearch.Config{
 		Username:   cfg.esUsername,

--- a/cmd/apmtool/main.go
+++ b/cmd/apmtool/main.go
@@ -83,7 +83,7 @@ func main() {
 			},
 			&cli.BoolFlag{
 				Name:        "insecure",
-				Usage:       "sets agents to skip the server's TLS certificate verification",
+				Usage:       "skip TLS certificate verification of Elasticsearch and APM server",
 				Value:       false,
 				Sources:     cli.EnvVars("TLS_SKIP_VERIFY"),
 				Destination: &commands.cfg.TLSSkipVerify,

--- a/cmd/apmtool/main.go
+++ b/cmd/apmtool/main.go
@@ -81,6 +81,14 @@ func main() {
 				Destination: &commands.cfg.APMServerURL,
 				Persistent:  true,
 			},
+			&cli.BoolFlag{
+				Name:        "insecure",
+				Usage:       "sets agents to skip the server's TLS certificate verification",
+				Value:       false,
+				Sources:     cli.EnvVars("TLS_SKIP_VERIFY"),
+				Destination: &commands.cfg.TLSSkipVerify,
+				Persistent:  true,
+			},
 		},
 		Commands: []*cli.Command{
 			NewPrintEnvCmd(commands),

--- a/cmd/apmtool/tracegen.go
+++ b/cmd/apmtool/tracegen.go
@@ -46,7 +46,7 @@ func (cmd *Commands) sendTrace(c *cli.Context) error {
 		tracegen.WithAPMServerURL(cmd.cfg.APMServerURL),
 		tracegen.WithAPIKey(creds.APIKey),
 		tracegen.WithSampleRate(c.Float64("sample-rate")),
-		tracegen.WithInsecureConn(c.Bool("insecure")),
+		tracegen.WithInsecureConn(cmd.cfg.TLSSkipVerify),
 		tracegen.WithElasticAPMTracer(apmTracer),
 		tracegen.WithOTLPProtocol(c.String("otlp-protocol")),
 		tracegen.WithOTLPServiceName(newUniqueServiceName("service", "otlp")),
@@ -85,11 +85,6 @@ func NewTraceGenCmd(commands *Commands) *cli.Command {
 				Name:  "sample-rate",
 				Usage: "set the sample rate. allowed value: min: 0.0001, max: 1.000",
 				Value: 1.0,
-			},
-			&cli.BoolFlag{
-				Name:  "insecure",
-				Usage: "sets agents to skip the server's TLS certificate verification",
-				Value: false,
 			},
 			&cli.StringFlag{
 				Name:  "otlp-protocol",

--- a/pkg/apmclient/config.go
+++ b/pkg/apmclient/config.go
@@ -50,6 +50,14 @@ type Config struct {
 	// If this is unspecified, it will be derived from
 	// ElasticsearchURL if that is an Elastic Cloud URL.
 	KibanaURL string
+
+	// TLSSkipVerify determines if TLS certificate
+	// verification is skipped or not. Default to false.
+	//
+	// If not specified the value will be take from
+	// TLS_ACCEPT_UNAUTHORIZED env var.
+	// Any value different from "" is considered true.
+	TLSSkipVerify bool
 }
 
 // NewConfig returns a Config intialised from environment variables.
@@ -91,6 +99,9 @@ func (cfg *Config) Finalize() error {
 	}
 	if cfg.KibanaURL == "" {
 		cfg.KibanaURL = os.Getenv("KIBANA_URL")
+	}
+	if env := os.Getenv("TLS_SKIP_VERIFY"); !cfg.TLSSkipVerify && env != "" {
+		cfg.TLSSkipVerify = true
 	}
 	return cfg.InferElasticCloudURLs()
 }

--- a/pkg/apmclient/config.go
+++ b/pkg/apmclient/config.go
@@ -55,7 +55,7 @@ type Config struct {
 	// verification is skipped or not. Default to false.
 	//
 	// If not specified the value will be take from
-	// TLS_ACCEPT_UNAUTHORIZED env var.
+	// TLS_SKIP_VERIFY env var.
 	// Any value different from "" is considered true.
 	TLSSkipVerify bool
 }


### PR DESCRIPTION
This PR adds a persistent `--insecure` flag (default value `false` for compatibility with `tracegen` command `--insecure` flag).

`apmclient.Config` gets an additional field, `TLSSkipVerify` that is by default false and is linked to the `TLS_SKIP_VERIFY` environment variable.

The flag value is used to configure `Commands.cfg`, it replaces `--insecure` flag in `tracegen` command and overrides (previously hardcoded) transport TLS configuration in `espoll` command.

Flag value can also be configured through `TLS_SKIP_VERIFY` environment variable.

Closes #13


