### PR TITLE
pkg/tracegen: add gzip compression to OTLP/gRPC

### DIFF
--- a/pkg/tracegen/otlp.go
+++ b/pkg/tracegen/otlp.go
@@ -166,7 +166,11 @@ func newOTLPGRPCExporters(ctx context.Context, endpointURL *url.URL, cfg Config)
 		transportCredentials = credentials.NewTLS(&tls.Config{InsecureSkipVerify: cfg.insecure})
 	}
 
-	grpcConn, err := grpc.DialContext(ctx, endpointURL.Host, grpc.WithTransportCredentials(transportCredentials))
+	grpcConn, err := grpc.DialContext(
+		ctx, endpointURL.Host,
+		grpc.WithTransportCredentials(transportCredentials),
+		grpc.WithDefaultCallOptions(grpc.UseCompressor("gzip")),
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Ensure apm-server's gRPC services support gzip request body compression by adding gzip compression to OTLP/gRPC requests as a sort of smoke test. No need to also test without compression, that's supported by the gRPC server by default.