### PR TITLE
github-actions: use ephemeral tokens for add to project

### DIFF
--- a/.github/workflows/apm-project.yml
+++ b/.github/workflows/apm-project.yml
@@ -10,6 +10,18 @@ jobs:
   add_to_project:
     runs-on: ubuntu-latest
     steps:
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "organization_projects": "write",
+              "issues": "read"
+            }
+
       - uses: octokit/graphql-action@v2.x
         id: add_to_project
         with:
@@ -27,7 +39,7 @@ jobs:
           contentid: ${{ github.event.issue.node_id }}
         env:
           PROJECT_ID: "PVT_kwDOAGc3Zs0VSg"
-          GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
       - uses: octokit/graphql-action@v2.x
         id: label_team
         with:
@@ -50,4 +62,4 @@ jobs:
           value: "6c538d8a"
         env:
           PROJECT_ID: "PVT_kwDOAGc3Zs0VSg"
-          GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}


### PR DESCRIPTION
No more finer-grained tokens but ephemeral tokens using a GH app