### PR TITLE
stats-to-mapping: merge into upstream entries instead of replacing them

### DIFF
--- a/cmd/stats-to-mapping/README.md
+++ b/cmd/stats-to-mapping/README.md
@@ -60,11 +60,23 @@ Both YAML and JSON modifications are byte-spliced: only the target subtree
 rewritten. Every byte outside those entries — comments, quoting, sibling
 keys, the version placeholder in the JSON templates — is preserved verbatim.
 
-Within the spliced subtree, JSON keys are emitted in alphabetical order
+Within each rewritten subtree, the new fields from `/stats` are **merged**
+into the existing upstream subtree rather than replacing it. Entries that
+only exist upstream (e.g. fields removed from `/stats` after a metric
+rename or feature removal — `agentcfg.elasticsearch.cache.entries.count`,
+the `jaeger.*` subtree, etc.) are kept; entries that only exist in
+`/stats` are added; entries that exist in both are recursed into when
+they're groups, and overwritten with the new typing when they're leaves.
+This keeps long-deprecated fields documented downstream without requiring
+a flag day in upstream PRs whenever apm-server drops a metric.
+
+Within the merged subtree, JSON keys are emitted in alphabetical order
 (stdlib `encoding/json`); alias entries emit `{type, path}` via a typed
-struct so field order matches the upstream Python reference. YAML emission
-follows the upstream conventions of those repos (4-column indent per
-nesting level, dashes at parent_col+2, mapping body at dash+2).
+struct so field order matches the upstream Python reference. YAML
+emission follows the upstream conventions of those repos (4-column
+indent per nesting level, dashes at parent_col+2, mapping body at
+dash+2). YAML preserves existing entry order at every level: upstream
+entries keep their position, new entries from `/stats` append after.
 
 ## Stats input shape
 

--- a/cmd/stats-to-mapping/jsonfile.go
+++ b/cmd/stats-to-mapping/jsonfile.go
@@ -36,9 +36,10 @@ import (
 )
 
 // modifyMonitoringBeats updates the legacy Elasticsearch monitoring
-// template, replacing each metric's value under
-// mappings._doc.properties.beats_stats.properties.metrics.properties.
-// Aliases are not used in this template.
+// template, merging each metric's new properties into the existing
+// subtree under mappings._doc.properties.beats_stats.properties.metrics
+// .properties. Aliases are not used in this template. Upstream entries
+// that have no counterpart in /stats are preserved (see merge.go).
 func modifyMonitoringBeats(path string, stats []byte) error {
 	const placeholder = "${xpack.monitoring.template.release.version}"
 	parent := []string{"mappings", "_doc", "properties", "beats_stats", "properties", "metrics", "properties"}
@@ -55,7 +56,8 @@ func modifyMonitoringBeats(path string, stats []byte) error {
 			warnMissing(m, path)
 			continue
 		}
-		src, err = replaceJSONMember(src, parent, m.name, map[string]any{"properties": props})
+		merged := mergeProperties(readJSONExistingProperties(src, parent, m.name), props)
+		src, err = replaceJSONMember(src, parent, m.name, map[string]any{"properties": merged})
 		if err != nil {
 			return err
 		}
@@ -64,9 +66,10 @@ func modifyMonitoringBeats(path string, stats []byte) error {
 }
 
 // modifyMonitoringBeatsMB updates the metricbeat-flavored monitoring
-// template, replacing two parallel subtrees: an alias-based view under
-// template.mappings.properties.beats_stats.properties.metrics and a
-// concrete-typed view under template.mappings.properties.beat.properties.stats.
+// template, merging into two parallel subtrees: an alias-based view
+// under template.mappings.properties.beats_stats.properties.metrics and
+// a concrete-typed view under template.mappings.properties.beat
+// .properties.stats. Upstream entries are preserved.
 func modifyMonitoringBeatsMB(path string, stats []byte) error {
 	const placeholder = "${xpack.stack.monitoring.template.release.version}"
 	aliasParent := []string{"template", "mappings", "properties", "beats_stats", "properties", "metrics", "properties"}
@@ -84,7 +87,8 @@ func modifyMonitoringBeatsMB(path string, stats []byte) error {
 			warnMissing(m, path)
 			continue
 		}
-		src, err = replaceJSONMember(src, aliasParent, m.name, map[string]any{"properties": aliasProps})
+		mergedAlias := mergeProperties(readJSONExistingProperties(src, aliasParent, m.name), aliasProps)
+		src, err = replaceJSONMember(src, aliasParent, m.name, map[string]any{"properties": mergedAlias})
 		if err != nil {
 			return err
 		}
@@ -96,12 +100,30 @@ func modifyMonitoringBeatsMB(path string, stats []byte) error {
 			continue
 		}
 		underscore := strings.ReplaceAll(m.name, "-", "_")
-		src, err = replaceJSONMember(src, statsParent, underscore, map[string]any{"properties": concreteProps})
+		mergedConcrete := mergeProperties(readJSONExistingProperties(src, statsParent, underscore), concreteProps)
+		src, err = replaceJSONMember(src, statsParent, underscore, map[string]any{"properties": mergedConcrete})
 		if err != nil {
 			return err
 		}
 	}
 	return writeJSONTemplate(path, src, placeholder)
+}
+
+// readJSONExistingProperties returns the existing properties map at
+// parent[member].properties in src, or nil if the member is absent or
+// not a group entry.
+func readJSONExistingProperties(src []byte, parent []string, member string) map[string]any {
+	keys := append(append([]string{}, parent...), member)
+	start, end, err := findJSONValueAt(src, keys)
+	if err != nil {
+		return nil
+	}
+	var v map[string]any
+	if err := json.Unmarshal(src[start:end], &v); err != nil {
+		return nil
+	}
+	props, _ := v["properties"].(map[string]any)
+	return props
 }
 
 // warnMissing prints a one-line note to stderr when a metric isn't present

--- a/cmd/stats-to-mapping/merge.go
+++ b/cmd/stats-to-mapping/merge.go
@@ -1,0 +1,122 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package main
+
+// Merge semantics for the regen output.
+//
+// The tool emits new field definitions for the apm-server and output
+// subtrees of each upstream mapping file. apm-server's history of
+// removed and renamed metrics (e.g. the Jaeger removal in #14791,
+// agentcfg.elasticsearch counter renames) means the upstream files
+// accumulate entries the current /stats no longer reports. Replacing
+// the subtree wholesale would silently delete those entries; downstream
+// dashboards and queries that still reference the old field names would
+// break the next time the regen output is committed.
+//
+// To avoid that, mergeProperties (JSON) and mergeFields (YAML) preserve
+// every upstream entry that has no counterpart in the new tree, and
+// recursively merge group entries that exist on both sides. Conflicts
+// (one side leaf, other side group; or scalar type mismatches) prefer
+// the new entry, on the assumption that /stats is the canonical source
+// for the current schema.
+
+// mergeProperties merges an Elasticsearch index template's properties
+// map (existing) with the regen tool's freshly produced properties map
+// (new_). The shape on both sides is {fieldName: entry}, where entry is
+// either {"type": "<scalar>"}, {"type": "alias", "path": ...}, or
+// {"properties": {...}} for nested groups.
+//
+// Returns existing if new_ is empty; returns new_ if existing is empty;
+// otherwise produces a fresh map with every key from existing plus
+// every key from new_, recursing into the "properties" map of group
+// entries when both sides agree the entry is a group.
+func mergeProperties(existing, new_ map[string]any) map[string]any {
+	if len(existing) == 0 {
+		return new_
+	}
+	if len(new_) == 0 {
+		return existing
+	}
+	out := make(map[string]any, len(existing)+len(new_))
+	for k, v := range existing {
+		out[k] = v
+	}
+	for k, v := range new_ {
+		ev, has := out[k]
+		if !has {
+			out[k] = v
+			continue
+		}
+		em, eOK := ev.(map[string]any)
+		nm, nOK := v.(map[string]any)
+		if !eOK || !nOK {
+			out[k] = v
+			continue
+		}
+		eProps, eIsGroup := em["properties"].(map[string]any)
+		nProps, nIsGroup := nm["properties"].(map[string]any)
+		if eIsGroup && nIsGroup {
+			out[k] = map[string]any{"properties": mergeProperties(eProps, nProps)}
+			continue
+		}
+		// One side is a leaf, or shapes disagree (e.g. group → leaf
+		// because a metric was demoted from a sub-tree to a single
+		// value). Prefer the new entry.
+		out[k] = v
+	}
+	return out
+}
+
+// mergeFields merges a YAML field tree (existing) with the regen tool's
+// freshly produced field tree (new_). Both sides are []item with the
+// shape used elsewhere in this package: groups have Type=="group" and
+// non-empty Fields; aliases have Type=="alias" and Path; leaves have a
+// scalar Type.
+//
+// Order is preserved: every upstream item retains its position; new
+// items not present upstream are appended in their input order.
+// Conflicts prefer the new item, with one exception — when both sides
+// are groups, their children are recursively merged.
+func mergeFields(existing, new_ []item) []item {
+	if len(existing) == 0 {
+		return new_
+	}
+	if len(new_) == 0 {
+		return existing
+	}
+	out := make([]item, len(existing))
+	copy(out, existing)
+	indexByName := make(map[string]int, len(out))
+	for i, it := range out {
+		indexByName[it.Name] = i
+	}
+	for _, n := range new_ {
+		i, has := indexByName[n.Name]
+		if !has {
+			indexByName[n.Name] = len(out)
+			out = append(out, n)
+			continue
+		}
+		if out[i].Type == "group" && n.Type == "group" {
+			out[i].Fields = mergeFields(out[i].Fields, n.Fields)
+			continue
+		}
+		out[i] = n
+	}
+	return out
+}

--- a/cmd/stats-to-mapping/merge_test.go
+++ b/cmd/stats-to-mapping/merge_test.go
@@ -1,0 +1,192 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMergeProperties(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing map[string]any
+		new_     map[string]any
+		want     map[string]any
+	}{{
+		name:     "existing only — entry kept",
+		existing: map[string]any{"deprecated": map[string]any{"type": "long"}},
+		new_:     nil,
+		want:     map[string]any{"deprecated": map[string]any{"type": "long"}},
+	}, {
+		name:     "new only — entry added",
+		existing: nil,
+		new_:     map[string]any{"fresh": map[string]any{"type": "long"}},
+		want:     map[string]any{"fresh": map[string]any{"type": "long"}},
+	}, {
+		name: "disjoint — both kept",
+		existing: map[string]any{
+			"deprecated": map[string]any{"type": "long"},
+		},
+		new_: map[string]any{
+			"current": map[string]any{"type": "long"},
+		},
+		want: map[string]any{
+			"deprecated": map[string]any{"type": "long"},
+			"current":    map[string]any{"type": "long"},
+		},
+	}, {
+		name: "leaf collision — new wins",
+		existing: map[string]any{
+			"x": map[string]any{"type": "long"},
+		},
+		new_: map[string]any{
+			"x": map[string]any{"type": "float"},
+		},
+		want: map[string]any{
+			"x": map[string]any{"type": "float"},
+		},
+	}, {
+		name: "groups recurse — children of both kept",
+		existing: map[string]any{
+			"errors": map[string]any{"properties": map[string]any{
+				"deprecated": map[string]any{"type": "long"},
+			}},
+		},
+		new_: map[string]any{
+			"errors": map[string]any{"properties": map[string]any{
+				"current": map[string]any{"type": "long"},
+			}},
+		},
+		want: map[string]any{
+			"errors": map[string]any{"properties": map[string]any{
+				"deprecated": map[string]any{"type": "long"},
+				"current":    map[string]any{"type": "long"},
+			}},
+		},
+	}, {
+		name: "shape mismatch — leaf to group prefers new",
+		existing: map[string]any{
+			"x": map[string]any{"type": "long"},
+		},
+		new_: map[string]any{
+			"x": map[string]any{"properties": map[string]any{
+				"y": map[string]any{"type": "long"},
+			}},
+		},
+		want: map[string]any{
+			"x": map[string]any{"properties": map[string]any{
+				"y": map[string]any{"type": "long"},
+			}},
+		},
+	}}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mergeProperties(tc.existing, tc.new_)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("\n got: %v\nwant: %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMergeFields(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing []item
+		new_     []item
+		want     []item
+	}{{
+		name:     "existing only — entry kept",
+		existing: []item{{Name: "deprecated", Type: "long"}},
+		new_:     nil,
+		want:     []item{{Name: "deprecated", Type: "long"}},
+	}, {
+		name:     "new only — entry added",
+		existing: nil,
+		new_:     []item{{Name: "fresh", Type: "long"}},
+		want:     []item{{Name: "fresh", Type: "long"}},
+	}, {
+		name: "existing order preserved, new appended",
+		existing: []item{
+			{Name: "a", Type: "long"},
+			{Name: "b", Type: "long"},
+		},
+		new_: []item{
+			{Name: "b", Type: "long"}, // already present
+			{Name: "c", Type: "long"}, // new
+		},
+		want: []item{
+			{Name: "a", Type: "long"},
+			{Name: "b", Type: "long"},
+			{Name: "c", Type: "long"},
+		},
+	}, {
+		name: "leaf collision — new wins",
+		existing: []item{
+			{Name: "x", Type: "long"},
+		},
+		new_: []item{
+			{Name: "x", Type: "float"},
+		},
+		want: []item{
+			{Name: "x", Type: "float"},
+		},
+	}, {
+		name: "groups recurse — children of both kept",
+		existing: []item{
+			{Name: "errors", Type: "group", Fields: []item{
+				{Name: "deprecated", Type: "long"},
+			}},
+		},
+		new_: []item{
+			{Name: "errors", Type: "group", Fields: []item{
+				{Name: "current", Type: "long"},
+			}},
+		},
+		want: []item{
+			{Name: "errors", Type: "group", Fields: []item{
+				{Name: "deprecated", Type: "long"},
+				{Name: "current", Type: "long"},
+			}},
+		},
+	}, {
+		name: "shape mismatch — leaf to group prefers new",
+		existing: []item{
+			{Name: "x", Type: "long"},
+		},
+		new_: []item{
+			{Name: "x", Type: "group", Fields: []item{
+				{Name: "y", Type: "long"},
+			}},
+		},
+		want: []item{
+			{Name: "x", Type: "group", Fields: []item{
+				{Name: "y", Type: "long"},
+			}},
+		},
+	}}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mergeFields(tc.existing, tc.new_)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("\n got: %v\nwant: %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/stats-to-mapping/parse_test.go
+++ b/cmd/stats-to-mapping/parse_test.go
@@ -53,7 +53,7 @@ func TestParseEntryFields_FoldedScalarSibling(t *testing.T) {
                   description: >
                     Number of requests received
 `)
-	got := parseEntryFields(entry, 4)
+	got := parseEntryFields(entry)
 	want := []item{
 		{Name: "sampling", Type: "group", Fields: []item{
 			{Name: "transactions_dropped", Type: "long"},

--- a/cmd/stats-to-mapping/parse_test.go
+++ b/cmd/stats-to-mapping/parse_test.go
@@ -1,0 +1,70 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestParseEntryFields_FoldedScalarSibling guards against a regression
+// where a folded scalar's continuation line (deeper than the entry's
+// mapping-pair indent) caused the parser to break out of the
+// surrounding entry, dropping every following sibling. The shape is
+// taken straight from elastic/integrations beat-stats-fields.yml.
+func TestParseEntryFields_FoldedScalarSibling(t *testing.T) {
+	entry := []byte(`    - name: apm_server
+      type: group
+      description: >
+        APM Server specific metrics
+      fields:
+        - name: sampling
+          type: group
+          fields:
+            - name: transactions_dropped
+              type: long
+              metric_type: counter
+              description: >
+                Number of transactions dropped
+        - name: server
+          type: group
+          fields:
+            - name: request
+              type: group
+              fields:
+                - name: count
+                  type: long
+                  metric_type: counter
+                  description: >
+                    Number of requests received
+`)
+	got := parseEntryFields(entry, 4)
+	want := []item{
+		{Name: "sampling", Type: "group", Fields: []item{
+			{Name: "transactions_dropped", Type: "long"},
+		}},
+		{Name: "server", Type: "group", Fields: []item{
+			{Name: "request", Type: "group", Fields: []item{
+				{Name: "count", Type: "long"},
+			}},
+		}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("\n got: %+v\nwant: %+v", got, want)
+	}
+}

--- a/cmd/stats-to-mapping/testdata/golden/beat-root-fields.yml
+++ b/cmd/stats-to-mapping/testdata/golden/beat-root-fields.yml
@@ -96,6 +96,27 @@
                 - name: elasticsearch
                   type: group
                   fields:
+                    - name: cache.entries.count
+                      type: alias
+                      path: beat.stats.apm_server.agentcfg.elasticsearch.cache.entries.count
+                    - name: cache.refresh.failures
+                      type: alias
+                      path: beat.stats.apm_server.agentcfg.elasticsearch.cache.refresh.failures
+                    - name: cache.refresh.successes
+                      type: alias
+                      path: beat.stats.apm_server.agentcfg.elasticsearch.cache.refresh.successes
+                    - name: fetch.es
+                      type: alias
+                      path: beat.stats.apm_server.agentcfg.elasticsearch.fetch.es
+                    - name: fetch.fallback
+                      type: alias
+                      path: beat.stats.apm_server.agentcfg.elasticsearch.fetch.fallback
+                    - name: fetch.invalid
+                      type: alias
+                      path: beat.stats.apm_server.agentcfg.elasticsearch.fetch.invalid
+                    - name: fetch.unavailable
+                      type: alias
+                      path: beat.stats.apm_server.agentcfg.elasticsearch.fetch.unavailable
                     - name: cache
                       type: group
                       fields:
@@ -126,6 +147,63 @@
                         - name: unavailable
                           type: alias
                           path: beat.stats.apm_server.agentcfg.elasticsearch.fetch.unavailable
+            - name: jaeger
+              type: group
+              fields:
+                - name: grpc
+                  type: group
+                  fields:
+                    - name: collect
+                      type: group
+                      fields:
+                        - name: request.count
+                          type: alias
+                          path: beat.stats.apm_server.jaeger.grpc.collect.request.count
+                        - name: response
+                          type: group
+                          fields:
+                            - name: count
+                              type: alias
+                              path: beat.stats.apm_server.jaeger.grpc.collect.response.count
+                            - name: errors
+                              type: group
+                              fields:
+                                - name: count
+                                  type: alias
+                                  path: beat.stats.apm_server.jaeger.grpc.collect.response.errors.count
+                                - name: ratelimit
+                                  type: alias
+                                  path: beat.stats.apm_server.jaeger.grpc.collect.response.errors.ratelimit
+                                - name: timeout
+                                  type: alias
+                                  path: beat.stats.apm_server.jaeger.grpc.collect.response.errors.timeout
+                                - name: unauthorized
+                                  type: alias
+                                  path: beat.stats.apm_server.jaeger.grpc.collect.response.errors.unauthorized
+                            - name: valid.count
+                              type: alias
+                              path: beat.stats.apm_server.jaeger.grpc.collect.response.valid.count
+                    - name: sampling
+                      type: group
+                      fields:
+                        - name: event.received.count
+                          type: alias
+                          path: beat.stats.apm_server.jaeger.grpc.sampling.event.received.count
+                        - name: request.count
+                          type: alias
+                          path: beat.stats.apm_server.jaeger.grpc.sampling.request.count
+                        - name: response
+                          type: group
+                          fields:
+                            - name: count
+                              type: alias
+                              path: beat.stats.apm_server.jaeger.grpc.sampling.response.count
+                            - name: errors.count
+                              type: alias
+                              path: beat.stats.apm_server.jaeger.grpc.sampling.response.errors.count
+                            - name: valid.count
+                              type: alias
+                              path: beat.stats.apm_server.jaeger.grpc.sampling.response.valid.count
             - name: otlp
               type: group
               fields:
@@ -147,12 +225,21 @@
                             - name: errors
                               type: group
                               fields:
-                                - name: closed
-                                  type: alias
-                                  path: beat.stats.apm_server.otlp.grpc.logs.response.errors.closed
                                 - name: count
                                   type: alias
                                   path: beat.stats.apm_server.otlp.grpc.logs.response.errors.count
+                                - name: ratelimit
+                                  type: alias
+                                  path: beat.stats.apm_server.otlp.grpc.logs.response.errors.ratelimit
+                                - name: timeout
+                                  type: alias
+                                  path: beat.stats.apm_server.otlp.grpc.logs.response.errors.timeout
+                                - name: unauthorized
+                                  type: alias
+                                  path: beat.stats.apm_server.otlp.grpc.logs.response.errors.unauthorized
+                                - name: closed
+                                  type: alias
+                                  path: beat.stats.apm_server.otlp.grpc.logs.response.errors.closed
                                 - name: decode
                                   type: alias
                                   path: beat.stats.apm_server.otlp.grpc.logs.response.errors.decode
@@ -174,24 +261,18 @@
                                 - name: queue
                                   type: alias
                                   path: beat.stats.apm_server.otlp.grpc.logs.response.errors.queue
-                                - name: ratelimit
-                                  type: alias
-                                  path: beat.stats.apm_server.otlp.grpc.logs.response.errors.ratelimit
-                                - name: timeout
-                                  type: alias
-                                  path: beat.stats.apm_server.otlp.grpc.logs.response.errors.timeout
                                 - name: toolarge
                                   type: alias
                                   path: beat.stats.apm_server.otlp.grpc.logs.response.errors.toolarge
-                                - name: unauthorized
-                                  type: alias
-                                  path: beat.stats.apm_server.otlp.grpc.logs.response.errors.unauthorized
                                 - name: unavailable
                                   type: alias
                                   path: beat.stats.apm_server.otlp.grpc.logs.response.errors.unavailable
                                 - name: validate
                                   type: alias
                                   path: beat.stats.apm_server.otlp.grpc.logs.response.errors.validate
+                            - name: valid.count
+                              type: alias
+                              path: beat.stats.apm_server.otlp.grpc.logs.response.valid.count
                             - name: valid
                               type: group
                               fields:
@@ -228,12 +309,21 @@
                             - name: errors
                               type: group
                               fields:
-                                - name: closed
-                                  type: alias
-                                  path: beat.stats.apm_server.otlp.grpc.metrics.response.errors.closed
                                 - name: count
                                   type: alias
                                   path: beat.stats.apm_server.otlp.grpc.metrics.response.errors.count
+                                - name: ratelimit
+                                  type: alias
+                                  path: beat.stats.apm_server.otlp.grpc.metrics.response.errors.ratelimit
+                                - name: timeout
+                                  type: alias
+                                  path: beat.stats.apm_server.otlp.grpc.metrics.response.errors.timeout
+                                - name: unauthorized
+                                  type: alias
+                                  path: beat.stats.apm_server.otlp.grpc.metrics.response.errors.unauthorized
+                                - name: closed
+                                  type: alias
+                                  path: beat.stats.apm_server.otlp.grpc.metrics.response.errors.closed
                                 - name: decode
                                   type: alias
                                   path: beat.stats.apm_server.otlp.grpc.metrics.response.errors.decode
@@ -255,24 +345,18 @@
                                 - name: queue
                                   type: alias
                                   path: beat.stats.apm_server.otlp.grpc.metrics.response.errors.queue
-                                - name: ratelimit
-                                  type: alias
-                                  path: beat.stats.apm_server.otlp.grpc.metrics.response.errors.ratelimit
-                                - name: timeout
-                                  type: alias
-                                  path: beat.stats.apm_server.otlp.grpc.metrics.response.errors.timeout
                                 - name: toolarge
                                   type: alias
                                   path: beat.stats.apm_server.otlp.grpc.metrics.response.errors.toolarge
-                                - name: unauthorized
-                                  type: alias
-                                  path: beat.stats.apm_server.otlp.grpc.metrics.response.errors.unauthorized
                                 - name: unavailable
                                   type: alias
                                   path: beat.stats.apm_server.otlp.grpc.metrics.response.errors.unavailable
                                 - name: validate
                                   type: alias
                                   path: beat.stats.apm_server.otlp.grpc.metrics.response.errors.validate
+                            - name: valid.count
+                              type: alias
+                              path: beat.stats.apm_server.otlp.grpc.metrics.response.valid.count
                             - name: valid
                               type: group
                               fields:
@@ -306,12 +390,21 @@
                             - name: errors
                               type: group
                               fields:
-                                - name: closed
-                                  type: alias
-                                  path: beat.stats.apm_server.otlp.grpc.traces.response.errors.closed
                                 - name: count
                                   type: alias
                                   path: beat.stats.apm_server.otlp.grpc.traces.response.errors.count
+                                - name: ratelimit
+                                  type: alias
+                                  path: beat.stats.apm_server.otlp.grpc.traces.response.errors.ratelimit
+                                - name: timeout
+                                  type: alias
+                                  path: beat.stats.apm_server.otlp.grpc.traces.response.errors.timeout
+                                - name: unauthorized
+                                  type: alias
+                                  path: beat.stats.apm_server.otlp.grpc.traces.response.errors.unauthorized
+                                - name: closed
+                                  type: alias
+                                  path: beat.stats.apm_server.otlp.grpc.traces.response.errors.closed
                                 - name: decode
                                   type: alias
                                   path: beat.stats.apm_server.otlp.grpc.traces.response.errors.decode
@@ -333,24 +426,18 @@
                                 - name: queue
                                   type: alias
                                   path: beat.stats.apm_server.otlp.grpc.traces.response.errors.queue
-                                - name: ratelimit
-                                  type: alias
-                                  path: beat.stats.apm_server.otlp.grpc.traces.response.errors.ratelimit
-                                - name: timeout
-                                  type: alias
-                                  path: beat.stats.apm_server.otlp.grpc.traces.response.errors.timeout
                                 - name: toolarge
                                   type: alias
                                   path: beat.stats.apm_server.otlp.grpc.traces.response.errors.toolarge
-                                - name: unauthorized
-                                  type: alias
-                                  path: beat.stats.apm_server.otlp.grpc.traces.response.errors.unauthorized
                                 - name: unavailable
                                   type: alias
                                   path: beat.stats.apm_server.otlp.grpc.traces.response.errors.unavailable
                                 - name: validate
                                   type: alias
                                   path: beat.stats.apm_server.otlp.grpc.traces.response.errors.validate
+                            - name: valid.count
+                              type: alias
+                              path: beat.stats.apm_server.otlp.grpc.traces.response.valid.count
                             - name: valid
                               type: group
                               fields:
@@ -387,12 +474,21 @@
                             - name: errors
                               type: group
                               fields:
-                                - name: closed
-                                  type: alias
-                                  path: beat.stats.apm_server.otlp.http.logs.response.errors.closed
                                 - name: count
                                   type: alias
                                   path: beat.stats.apm_server.otlp.http.logs.response.errors.count
+                                - name: ratelimit
+                                  type: alias
+                                  path: beat.stats.apm_server.otlp.http.logs.response.errors.ratelimit
+                                - name: timeout
+                                  type: alias
+                                  path: beat.stats.apm_server.otlp.http.logs.response.errors.timeout
+                                - name: unauthorized
+                                  type: alias
+                                  path: beat.stats.apm_server.otlp.http.logs.response.errors.unauthorized
+                                - name: closed
+                                  type: alias
+                                  path: beat.stats.apm_server.otlp.http.logs.response.errors.closed
                                 - name: decode
                                   type: alias
                                   path: beat.stats.apm_server.otlp.http.logs.response.errors.decode
@@ -414,24 +510,18 @@
                                 - name: queue
                                   type: alias
                                   path: beat.stats.apm_server.otlp.http.logs.response.errors.queue
-                                - name: ratelimit
-                                  type: alias
-                                  path: beat.stats.apm_server.otlp.http.logs.response.errors.ratelimit
-                                - name: timeout
-                                  type: alias
-                                  path: beat.stats.apm_server.otlp.http.logs.response.errors.timeout
                                 - name: toolarge
                                   type: alias
                                   path: beat.stats.apm_server.otlp.http.logs.response.errors.toolarge
-                                - name: unauthorized
-                                  type: alias
-                                  path: beat.stats.apm_server.otlp.http.logs.response.errors.unauthorized
                                 - name: unavailable
                                   type: alias
                                   path: beat.stats.apm_server.otlp.http.logs.response.errors.unavailable
                                 - name: validate
                                   type: alias
                                   path: beat.stats.apm_server.otlp.http.logs.response.errors.validate
+                            - name: valid.count
+                              type: alias
+                              path: beat.stats.apm_server.otlp.http.logs.response.valid.count
                             - name: valid
                               type: group
                               fields:
@@ -468,12 +558,21 @@
                             - name: errors
                               type: group
                               fields:
-                                - name: closed
-                                  type: alias
-                                  path: beat.stats.apm_server.otlp.http.metrics.response.errors.closed
                                 - name: count
                                   type: alias
                                   path: beat.stats.apm_server.otlp.http.metrics.response.errors.count
+                                - name: ratelimit
+                                  type: alias
+                                  path: beat.stats.apm_server.otlp.http.metrics.response.errors.ratelimit
+                                - name: timeout
+                                  type: alias
+                                  path: beat.stats.apm_server.otlp.http.metrics.response.errors.timeout
+                                - name: unauthorized
+                                  type: alias
+                                  path: beat.stats.apm_server.otlp.http.metrics.response.errors.unauthorized
+                                - name: closed
+                                  type: alias
+                                  path: beat.stats.apm_server.otlp.http.metrics.response.errors.closed
                                 - name: decode
                                   type: alias
                                   path: beat.stats.apm_server.otlp.http.metrics.response.errors.decode
@@ -495,24 +594,18 @@
                                 - name: queue
                                   type: alias
                                   path: beat.stats.apm_server.otlp.http.metrics.response.errors.queue
-                                - name: ratelimit
-                                  type: alias
-                                  path: beat.stats.apm_server.otlp.http.metrics.response.errors.ratelimit
-                                - name: timeout
-                                  type: alias
-                                  path: beat.stats.apm_server.otlp.http.metrics.response.errors.timeout
                                 - name: toolarge
                                   type: alias
                                   path: beat.stats.apm_server.otlp.http.metrics.response.errors.toolarge
-                                - name: unauthorized
-                                  type: alias
-                                  path: beat.stats.apm_server.otlp.http.metrics.response.errors.unauthorized
                                 - name: unavailable
                                   type: alias
                                   path: beat.stats.apm_server.otlp.http.metrics.response.errors.unavailable
                                 - name: validate
                                   type: alias
                                   path: beat.stats.apm_server.otlp.http.metrics.response.errors.validate
+                            - name: valid.count
+                              type: alias
+                              path: beat.stats.apm_server.otlp.http.metrics.response.valid.count
                             - name: valid
                               type: group
                               fields:
@@ -546,12 +639,21 @@
                             - name: errors
                               type: group
                               fields:
-                                - name: closed
-                                  type: alias
-                                  path: beat.stats.apm_server.otlp.http.traces.response.errors.closed
                                 - name: count
                                   type: alias
                                   path: beat.stats.apm_server.otlp.http.traces.response.errors.count
+                                - name: ratelimit
+                                  type: alias
+                                  path: beat.stats.apm_server.otlp.http.traces.response.errors.ratelimit
+                                - name: timeout
+                                  type: alias
+                                  path: beat.stats.apm_server.otlp.http.traces.response.errors.timeout
+                                - name: unauthorized
+                                  type: alias
+                                  path: beat.stats.apm_server.otlp.http.traces.response.errors.unauthorized
+                                - name: closed
+                                  type: alias
+                                  path: beat.stats.apm_server.otlp.http.traces.response.errors.closed
                                 - name: decode
                                   type: alias
                                   path: beat.stats.apm_server.otlp.http.traces.response.errors.decode
@@ -573,24 +675,18 @@
                                 - name: queue
                                   type: alias
                                   path: beat.stats.apm_server.otlp.http.traces.response.errors.queue
-                                - name: ratelimit
-                                  type: alias
-                                  path: beat.stats.apm_server.otlp.http.traces.response.errors.ratelimit
-                                - name: timeout
-                                  type: alias
-                                  path: beat.stats.apm_server.otlp.http.traces.response.errors.timeout
                                 - name: toolarge
                                   type: alias
                                   path: beat.stats.apm_server.otlp.http.traces.response.errors.toolarge
-                                - name: unauthorized
-                                  type: alias
-                                  path: beat.stats.apm_server.otlp.http.traces.response.errors.unauthorized
                                 - name: unavailable
                                   type: alias
                                   path: beat.stats.apm_server.otlp.http.traces.response.errors.unavailable
                                 - name: validate
                                   type: alias
                                   path: beat.stats.apm_server.otlp.http.traces.response.errors.validate
+                            - name: valid.count
+                              type: alias
+                              path: beat.stats.apm_server.otlp.http.traces.response.valid.count
                             - name: valid
                               type: group
                               fields:
@@ -615,9 +711,6 @@
                 - name: error.transformations
                   type: alias
                   path: beat.stats.apm_server.processor.error.transformations
-                - name: log.transformations
-                  type: alias
-                  path: beat.stats.apm_server.processor.log.transformations
                 - name: metric.transformations
                   type: alias
                   path: beat.stats.apm_server.processor.metric.transformations
@@ -642,6 +735,9 @@
                 - name: transaction.transformations
                   type: alias
                   path: beat.stats.apm_server.processor.transaction.transformations
+                - name: log.transformations
+                  type: alias
+                  path: beat.stats.apm_server.processor.log.transformations
                 - name: undefined.transformations
                   type: alias
                   path: beat.stats.apm_server.processor.undefined.transformations
@@ -756,24 +852,24 @@
                     - name: storage
                       type: group
                       fields:
+                        - name: lsm_size
+                          type: alias
+                          path: beat.stats.apm_server.sampling.tail.storage.lsm_size
+                        - name: value_log_size
+                          type: alias
+                          path: beat.stats.apm_server.sampling.tail.storage.value_log_size
+                        - name: storage_limit
+                          type: alias
+                          path: beat.stats.apm_server.sampling.tail.storage.storage_limit
+                        - name: disk_used
+                          type: alias
+                          path: beat.stats.apm_server.sampling.tail.storage.disk_used
                         - name: disk_total
                           type: alias
                           path: beat.stats.apm_server.sampling.tail.storage.disk_total
                         - name: disk_usage_threshold_pct
                           type: alias
                           path: beat.stats.apm_server.sampling.tail.storage.disk_usage_threshold_pct
-                        - name: disk_used
-                          type: alias
-                          path: beat.stats.apm_server.sampling.tail.storage.disk_used
-                        - name: lsm_size
-                          type: alias
-                          path: beat.stats.apm_server.sampling.tail.storage.lsm_size
-                        - name: storage_limit
-                          type: alias
-                          path: beat.stats.apm_server.sampling.tail.storage.storage_limit
-                        - name: value_log_size
-                          type: alias
-                          path: beat.stats.apm_server.sampling.tail.storage.value_log_size
                 - name: transactions_dropped
                   type: alias
                   path: beat.stats.apm_server.sampling.transactions_dropped
@@ -1105,6 +1201,30 @@
         - name: output
           type: group
           fields:
+            - name: elasticsearch
+              type: group
+              fields:
+                - name: bulk_requests
+                  type: group
+                  fields:
+                    - name: available
+                      type: alias
+                      path: beat.stats.output.elasticsearch.bulk_requests.available
+                    - name: completed
+                      type: alias
+                      path: beat.stats.output.elasticsearch.bulk_requests.completed
+                - name: indexers
+                  type: group
+                  fields:
+                    - name: active
+                      type: alias
+                      path: beat.stats.output.elasticsearch.indexers.active
+                    - name: created
+                      type: alias
+                      path: beat.stats.output.elasticsearch.indexers.created
+                    - name: destroyed
+                      type: alias
+                      path: beat.stats.output.elasticsearch.indexers.destroyed
             - name: events
               type: group
               fields:

--- a/cmd/stats-to-mapping/testdata/golden/beat-stats-fields.yml
+++ b/cmd/stats-to-mapping/testdata/golden/beat-stats-fields.yml
@@ -69,6 +69,20 @@
             - name: elasticsearch
               type: group
               fields:
+                - name: cache.entries.count
+                  type: long
+                - name: cache.refresh.failures
+                  type: long
+                - name: cache.refresh.successes
+                  type: long
+                - name: fetch.es
+                  type: long
+                - name: fetch.fallback
+                  type: long
+                - name: fetch.invalid
+                  type: long
+                - name: fetch.unavailable
+                  type: long
                 - name: cache
                   type: group
                   fields:
@@ -92,6 +106,51 @@
                       type: long
                     - name: unavailable
                       type: long
+        - name: jaeger
+          type: group
+          fields:
+            - name: grpc
+              type: group
+              fields:
+                - name: collect
+                  type: group
+                  fields:
+                    - name: request.count
+                      type: long
+                    - name: response
+                      type: group
+                      fields:
+                        - name: count
+                          type: long
+                        - name: errors
+                          type: group
+                          fields:
+                            - name: count
+                              type: long
+                            - name: ratelimit
+                              type: long
+                            - name: timeout
+                              type: long
+                            - name: unauthorized
+                              type: long
+                        - name: valid.count
+                          type: long
+                - name: sampling
+                  type: group
+                  fields:
+                    - name: event.received.count
+                      type: long
+                    - name: request.count
+                      type: long
+                    - name: response
+                      type: group
+                      fields:
+                        - name: count
+                          type: long
+                        - name: errors.count
+                          type: long
+                        - name: valid.count
+                          type: long
         - name: otlp
           type: group
           fields:
@@ -111,9 +170,15 @@
                         - name: errors
                           type: group
                           fields:
-                            - name: closed
-                              type: long
                             - name: count
+                              type: long
+                            - name: ratelimit
+                              type: long
+                            - name: timeout
+                              type: long
+                            - name: unauthorized
+                              type: long
+                            - name: closed
                               type: long
                             - name: decode
                               type: long
@@ -129,18 +194,14 @@
                               type: long
                             - name: queue
                               type: long
-                            - name: ratelimit
-                              type: long
-                            - name: timeout
-                              type: long
                             - name: toolarge
-                              type: long
-                            - name: unauthorized
                               type: long
                             - name: unavailable
                               type: long
                             - name: validate
                               type: long
+                        - name: valid.count
+                          type: long
                         - name: valid
                           type: group
                           fields:
@@ -169,9 +230,15 @@
                         - name: errors
                           type: group
                           fields:
-                            - name: closed
-                              type: long
                             - name: count
+                              type: long
+                            - name: ratelimit
+                              type: long
+                            - name: timeout
+                              type: long
+                            - name: unauthorized
+                              type: long
+                            - name: closed
                               type: long
                             - name: decode
                               type: long
@@ -187,18 +254,14 @@
                               type: long
                             - name: queue
                               type: long
-                            - name: ratelimit
-                              type: long
-                            - name: timeout
-                              type: long
                             - name: toolarge
-                              type: long
-                            - name: unauthorized
                               type: long
                             - name: unavailable
                               type: long
                             - name: validate
                               type: long
+                        - name: valid.count
+                          type: long
                         - name: valid
                           type: group
                           fields:
@@ -225,9 +288,15 @@
                         - name: errors
                           type: group
                           fields:
-                            - name: closed
-                              type: long
                             - name: count
+                              type: long
+                            - name: ratelimit
+                              type: long
+                            - name: timeout
+                              type: long
+                            - name: unauthorized
+                              type: long
+                            - name: closed
                               type: long
                             - name: decode
                               type: long
@@ -243,18 +312,14 @@
                               type: long
                             - name: queue
                               type: long
-                            - name: ratelimit
-                              type: long
-                            - name: timeout
-                              type: long
                             - name: toolarge
-                              type: long
-                            - name: unauthorized
                               type: long
                             - name: unavailable
                               type: long
                             - name: validate
                               type: long
+                        - name: valid.count
+                          type: long
                         - name: valid
                           type: group
                           fields:
@@ -284,9 +349,15 @@
                         - name: errors
                           type: group
                           fields:
-                            - name: closed
-                              type: long
                             - name: count
+                              type: long
+                            - name: ratelimit
+                              type: long
+                            - name: timeout
+                              type: long
+                            - name: unauthorized
+                              type: long
+                            - name: closed
                               type: long
                             - name: decode
                               type: long
@@ -302,18 +373,14 @@
                               type: long
                             - name: queue
                               type: long
-                            - name: ratelimit
-                              type: long
-                            - name: timeout
-                              type: long
                             - name: toolarge
-                              type: long
-                            - name: unauthorized
                               type: long
                             - name: unavailable
                               type: long
                             - name: validate
                               type: long
+                        - name: valid.count
+                          type: long
                         - name: valid
                           type: group
                           fields:
@@ -342,9 +409,15 @@
                         - name: errors
                           type: group
                           fields:
-                            - name: closed
-                              type: long
                             - name: count
+                              type: long
+                            - name: ratelimit
+                              type: long
+                            - name: timeout
+                              type: long
+                            - name: unauthorized
+                              type: long
+                            - name: closed
                               type: long
                             - name: decode
                               type: long
@@ -360,18 +433,14 @@
                               type: long
                             - name: queue
                               type: long
-                            - name: ratelimit
-                              type: long
-                            - name: timeout
-                              type: long
                             - name: toolarge
-                              type: long
-                            - name: unauthorized
                               type: long
                             - name: unavailable
                               type: long
                             - name: validate
                               type: long
+                        - name: valid.count
+                          type: long
                         - name: valid
                           type: group
                           fields:
@@ -398,9 +467,15 @@
                         - name: errors
                           type: group
                           fields:
-                            - name: closed
-                              type: long
                             - name: count
+                              type: long
+                            - name: ratelimit
+                              type: long
+                            - name: timeout
+                              type: long
+                            - name: unauthorized
+                              type: long
+                            - name: closed
                               type: long
                             - name: decode
                               type: long
@@ -416,18 +491,14 @@
                               type: long
                             - name: queue
                               type: long
-                            - name: ratelimit
-                              type: long
-                            - name: timeout
-                              type: long
                             - name: toolarge
-                              type: long
-                            - name: unauthorized
                               type: long
                             - name: unavailable
                               type: long
                             - name: validate
                               type: long
+                        - name: valid.count
+                          type: long
                         - name: valid
                           type: group
                           fields:
@@ -446,8 +517,6 @@
           fields:
             - name: error.transformations
               type: long
-            - name: log.transformations
-              type: long
             - name: metric.transformations
               type: long
             - name: span.transformations
@@ -465,6 +534,8 @@
                     - name: toolarge
                       type: long
             - name: transaction.transformations
+              type: long
+            - name: log.transformations
               type: long
             - name: undefined.transformations
               type: long
@@ -550,18 +621,18 @@
                 - name: storage
                   type: group
                   fields:
+                    - name: lsm_size
+                      type: long
+                    - name: value_log_size
+                      type: long
+                    - name: storage_limit
+                      type: long
+                    - name: disk_used
+                      type: long
                     - name: disk_total
                       type: long
                     - name: disk_usage_threshold_pct
                       type: float
-                    - name: disk_used
-                      type: long
-                    - name: lsm_size
-                      type: long
-                    - name: storage_limit
-                      type: long
-                    - name: value_log_size
-                      type: long
             - name: transactions_dropped
               type: long
         - name: server
@@ -946,6 +1017,25 @@
     - name: output
       type: group
       fields:
+        - name: elasticsearch
+          type: group
+          fields:
+            - name: bulk_requests
+              type: group
+              fields:
+                - name: available
+                  type: long
+                - name: completed
+                  type: long
+            - name: indexers
+              type: group
+              fields:
+                - name: active
+                  type: long
+                - name: created
+                  type: long
+                - name: destroyed
+                  type: long
         - name: events
           type: group
           fields:

--- a/cmd/stats-to-mapping/testdata/golden/ea-beat-stats-fields.yml
+++ b/cmd/stats-to-mapping/testdata/golden/ea-beat-stats-fields.yml
@@ -350,33 +350,117 @@
                     - name: stored
                       type: long
                       metric_type: counter
-                - name: dynamic_service_groups
-                  type: long
-                  metric_type: FIXME
                 - name: storage
                   type: group
                   fields:
+                    - name: lsm_size
+                      type: long
+                      metric_type: gauge
+                    - name: value_log_size
+                      type: long
+                      metric_type: gauge
+                    - name: storage_limit
+                      type: long
+                      metric_type: gauge
+                    - name: disk_used
+                      type: long
+                      metric_type: gauge
                     - name: disk_total
                       type: long
                       metric_type: gauge
                     - name: disk_usage_threshold_pct
                       type: float
                       metric_type: gauge
-                    - name: disk_used
-                      type: long
-                      metric_type: gauge
-                    - name: lsm_size
-                      type: long
-                      metric_type: gauge
-                    - name: storage_limit
-                      type: long
-                      metric_type: gauge
-                    - name: value_log_size
-                      type: long
-                      metric_type: gauge
+                - name: dynamic_service_groups
+                  type: long
+                  metric_type: FIXME
             - name: transactions_dropped
               type: long
               metric_type: counter
+        - name: server
+          type: group
+          fields:
+            - name: request
+              type: group
+              fields:
+                - name: count
+                  type: long
+                  metric_type: counter
+            - name: request.count
+              type: long
+              metric_type: counter
+            - name: response
+              type: group
+              fields:
+                - name: count
+                  type: long
+                  metric_type: FIXME
+                - name: errors
+                  type: group
+                  fields:
+                    - name: closed
+                      type: long
+                      metric_type: FIXME
+                    - name: count
+                      type: long
+                      metric_type: FIXME
+                    - name: decode
+                      type: long
+                      metric_type: FIXME
+                    - name: forbidden
+                      type: long
+                      metric_type: FIXME
+                    - name: internal
+                      type: long
+                      metric_type: FIXME
+                    - name: invalidquery
+                      type: long
+                      metric_type: FIXME
+                    - name: method
+                      type: long
+                      metric_type: FIXME
+                    - name: notfound
+                      type: long
+                      metric_type: FIXME
+                    - name: queue
+                      type: long
+                      metric_type: FIXME
+                    - name: ratelimit
+                      type: long
+                      metric_type: FIXME
+                    - name: timeout
+                      type: long
+                      metric_type: FIXME
+                    - name: toolarge
+                      type: long
+                      metric_type: FIXME
+                    - name: unauthorized
+                      type: long
+                      metric_type: FIXME
+                    - name: unavailable
+                      type: long
+                      metric_type: FIXME
+                    - name: validate
+                      type: long
+                      metric_type: FIXME
+                - name: valid
+                  type: group
+                  fields:
+                    - name: accepted
+                      type: long
+                      metric_type: FIXME
+                    - name: count
+                      type: long
+                      metric_type: FIXME
+                    - name: notmodified
+                      type: long
+                      metric_type: FIXME
+                    - name: ok
+                      type: long
+                      metric_type: FIXME
+            - name: unset
+              type: long
+              metric_type: FIXME
         - name: acm
           type: group
           fields:
@@ -1016,84 +1100,6 @@
             - name: request.count
               type: long
               metric_type: FIXME
-            - name: response
-              type: group
-              fields:
-                - name: count
-                  type: long
-                  metric_type: FIXME
-                - name: errors
-                  type: group
-                  fields:
-                    - name: closed
-                      type: long
-                      metric_type: FIXME
-                    - name: count
-                      type: long
-                      metric_type: FIXME
-                    - name: decode
-                      type: long
-                      metric_type: FIXME
-                    - name: forbidden
-                      type: long
-                      metric_type: FIXME
-                    - name: internal
-                      type: long
-                      metric_type: FIXME
-                    - name: invalidquery
-                      type: long
-                      metric_type: FIXME
-                    - name: method
-                      type: long
-                      metric_type: FIXME
-                    - name: notfound
-                      type: long
-                      metric_type: FIXME
-                    - name: queue
-                      type: long
-                      metric_type: FIXME
-                    - name: ratelimit
-                      type: long
-                      metric_type: FIXME
-                    - name: timeout
-                      type: long
-                      metric_type: FIXME
-                    - name: toolarge
-                      type: long
-                      metric_type: FIXME
-                    - name: unauthorized
-                      type: long
-                      metric_type: FIXME
-                    - name: unavailable
-                      type: long
-                      metric_type: FIXME
-                    - name: validate
-                      type: long
-                      metric_type: FIXME
-                - name: valid
-                  type: group
-                  fields:
-                    - name: accepted
-                      type: long
-                      metric_type: FIXME
-                    - name: count
-                      type: long
-                      metric_type: FIXME
-                    - name: notmodified
-                      type: long
-                      metric_type: FIXME
-                    - name: ok
-                      type: long
-                      metric_type: FIXME
-            - name: unset
-              type: long
-              metric_type: FIXME
-        - name: server
-          type: group
-          fields:
-            - name: request.count
-              type: long
-              metric_type: counter
             - name: response
               type: group
               fields:

--- a/cmd/stats-to-mapping/testdata/golden/ea-beat-stats-fields.yml
+++ b/cmd/stats-to-mapping/testdata/golden/ea-beat-stats-fields.yml
@@ -323,6 +323,60 @@
     - name: apm_server
       type: group
       fields:
+        - name: sampling
+          type: group
+          fields:
+            - name: tail
+              type: group
+              fields:
+                - name: events
+                  type: group
+                  fields:
+                    - name: dropped
+                      type: long
+                      metric_type: counter
+                    - name: failed_writes
+                      type: long
+                      metric_type: counter
+                    - name: head_unsampled
+                      type: long
+                      metric_type: counter
+                    - name: processed
+                      type: long
+                      metric_type: counter
+                    - name: sampled
+                      type: long
+                      metric_type: counter
+                    - name: stored
+                      type: long
+                      metric_type: counter
+                - name: dynamic_service_groups
+                  type: long
+                  metric_type: FIXME
+                - name: storage
+                  type: group
+                  fields:
+                    - name: disk_total
+                      type: long
+                      metric_type: gauge
+                    - name: disk_usage_threshold_pct
+                      type: float
+                      metric_type: gauge
+                    - name: disk_used
+                      type: long
+                      metric_type: gauge
+                    - name: lsm_size
+                      type: long
+                      metric_type: gauge
+                    - name: storage_limit
+                      type: long
+                      metric_type: gauge
+                    - name: value_log_size
+                      type: long
+                      metric_type: gauge
+            - name: transactions_dropped
+              type: long
+              metric_type: counter
         - name: acm
           type: group
           fields:
@@ -1034,60 +1088,6 @@
             - name: unset
               type: long
               metric_type: FIXME
-        - name: sampling
-          type: group
-          fields:
-            - name: tail
-              type: group
-              fields:
-                - name: dynamic_service_groups
-                  type: long
-                  metric_type: FIXME
-                - name: events
-                  type: group
-                  fields:
-                    - name: dropped
-                      type: long
-                      metric_type: counter
-                    - name: failed_writes
-                      type: long
-                      metric_type: counter
-                    - name: head_unsampled
-                      type: long
-                      metric_type: counter
-                    - name: processed
-                      type: long
-                      metric_type: counter
-                    - name: sampled
-                      type: long
-                      metric_type: counter
-                    - name: stored
-                      type: long
-                      metric_type: counter
-                - name: storage
-                  type: group
-                  fields:
-                    - name: disk_total
-                      type: long
-                      metric_type: gauge
-                    - name: disk_usage_threshold_pct
-                      type: float
-                      metric_type: gauge
-                    - name: disk_used
-                      type: long
-                      metric_type: gauge
-                    - name: lsm_size
-                      type: long
-                      metric_type: gauge
-                    - name: storage_limit
-                      type: long
-                      metric_type: gauge
-                    - name: value_log_size
-                      type: long
-                      metric_type: gauge
-            - name: transactions_dropped
-              type: long
-              metric_type: counter
         - name: server
           type: group
           fields:

--- a/cmd/stats-to-mapping/testdata/golden/monitoring-beats-mb.json
+++ b/cmd/stats-to-mapping/testdata/golden/monitoring-beats-mb.json
@@ -285,6 +285,98 @@
                         }
                       }
                     },
+                    "jaeger": {
+                      "properties": {
+                        "grpc": {
+                          "properties": {
+                            "collect": {
+                              "properties": {
+                                "request": {
+                                  "properties": {
+                                    "count": {
+                                      "type": "long"
+                                    }
+                                  }
+                                },
+                                "response": {
+                                  "properties": {
+                                    "count": {
+                                      "type": "long"
+                                    },
+                                    "errors": {
+                                      "properties": {
+                                        "count": {
+                                          "type": "long"
+                                        },
+                                        "ratelimit": {
+                                          "type": "long"
+                                        },
+                                        "timeout": {
+                                          "type": "long"
+                                        },
+                                        "unauthorized": {
+                                          "type": "long"
+                                        }
+                                      }
+                                    },
+                                    "valid": {
+                                      "properties": {
+                                        "count": {
+                                          "type": "long"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "sampling": {
+                              "properties": {
+                                "event": {
+                                  "properties": {
+                                    "received": {
+                                      "properties": {
+                                        "count": {
+                                          "type": "long"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "request": {
+                                  "properties": {
+                                    "count": {
+                                      "type": "long"
+                                    }
+                                  }
+                                },
+                                "response": {
+                                  "properties": {
+                                    "count": {
+                                      "type": "long"
+                                    },
+                                    "errors": {
+                                      "properties": {
+                                        "count": {
+                                          "type": "long"
+                                        }
+                                      }
+                                    },
+                                    "valid": {
+                                      "properties": {
+                                        "count": {
+                                          "type": "long"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
                     "otlp": {
                       "properties": {
                         "grpc": {
@@ -1053,6 +1145,9 @@
                                 "closed": {
                                   "type": "long"
                                 },
+                                "concurrency": {
+                                  "type": "long"
+                                },
                                 "count": {
                                   "type": "long"
                                 },
@@ -1529,6 +1624,33 @@
                 },
                 "output": {
                   "properties": {
+                    "elasticsearch": {
+                      "properties": {
+                        "bulk_requests": {
+                          "properties": {
+                            "available": {
+                              "type": "long"
+                            },
+                            "completed": {
+                              "type": "long"
+                            }
+                          }
+                        },
+                        "indexers": {
+                          "properties": {
+                            "active": {
+                              "type": "long"
+                            },
+                            "created": {
+                              "type": "long"
+                            },
+                            "destroyed": {
+                              "type": "long"
+                            }
+                          }
+                        }
+                      }
+                    },
                     "events": {
                       "properties": {
                         "acked": {
@@ -1874,6 +1996,110 @@
                                 "unavailable": {
                                   "type": "alias",
                                   "path": "beat.stats.apm_server.agentcfg.elasticsearch.fetch.unavailable"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "jaeger": {
+                      "properties": {
+                        "grpc": {
+                          "properties": {
+                            "collect": {
+                              "properties": {
+                                "request": {
+                                  "properties": {
+                                    "count": {
+                                      "path": "beat.stats.apm_server.jaeger.grpc.collect.request.count",
+                                      "type": "alias"
+                                    }
+                                  }
+                                },
+                                "response": {
+                                  "properties": {
+                                    "count": {
+                                      "path": "beat.stats.apm_server.jaeger.grpc.collect.response.count",
+                                      "type": "alias"
+                                    },
+                                    "errors": {
+                                      "properties": {
+                                        "count": {
+                                          "path": "beat.stats.apm_server.jaeger.grpc.collect.response.errors.count",
+                                          "type": "alias"
+                                        },
+                                        "ratelimit": {
+                                          "path": "beat.stats.apm_server.jaeger.grpc.collect.response.errors.ratelimit",
+                                          "type": "alias"
+                                        },
+                                        "timeout": {
+                                          "path": "beat.stats.apm_server.jaeger.grpc.collect.response.errors.timeout",
+                                          "type": "alias"
+                                        },
+                                        "unauthorized": {
+                                          "path": "beat.stats.apm_server.jaeger.grpc.collect.response.errors.unauthorized",
+                                          "type": "alias"
+                                        }
+                                      }
+                                    },
+                                    "valid": {
+                                      "properties": {
+                                        "count": {
+                                          "path": "beat.stats.apm_server.jaeger.grpc.collect.response.valid.count",
+                                          "type": "alias"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "sampling": {
+                              "properties": {
+                                "event": {
+                                  "properties": {
+                                    "received": {
+                                      "properties": {
+                                        "count": {
+                                          "path": "beat.stats.apm_server.jaeger.grpc.sampling.event.received.count",
+                                          "type": "alias"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "request": {
+                                  "properties": {
+                                    "count": {
+                                      "path": "beat.stats.apm_server.jaeger.grpc.sampling.request.count",
+                                      "type": "alias"
+                                    }
+                                  }
+                                },
+                                "response": {
+                                  "properties": {
+                                    "count": {
+                                      "path": "beat.stats.apm_server.jaeger.grpc.sampling.response.count",
+                                      "type": "alias"
+                                    },
+                                    "errors": {
+                                      "properties": {
+                                        "count": {
+                                          "path": "beat.stats.apm_server.jaeger.grpc.sampling.response.errors.count",
+                                          "type": "alias"
+                                        }
+                                      }
+                                    },
+                                    "valid": {
+                                      "properties": {
+                                        "count": {
+                                          "path": "beat.stats.apm_server.jaeger.grpc.sampling.response.valid.count",
+                                          "type": "alias"
+                                        }
+                                      }
+                                    }
+                                  }
                                 }
                               }
                             }
@@ -2831,6 +3057,10 @@
                                   "type": "alias",
                                   "path": "beat.stats.apm_server.server.response.errors.closed"
                                 },
+                                "concurrency": {
+                                  "path": "beat.stats.apm_server.server.response.errors.concurrency",
+                                  "type": "alias"
+                                },
                                 "count": {
                                   "type": "alias",
                                   "path": "beat.stats.apm_server.server.response.errors.count"
@@ -3349,6 +3579,38 @@
                 },
                 "output": {
                   "properties": {
+                    "elasticsearch": {
+                      "properties": {
+                        "bulk_requests": {
+                          "properties": {
+                            "available": {
+                              "path": "beat.stats.output.elasticsearch.bulk_requests.available",
+                              "type": "alias"
+                            },
+                            "completed": {
+                              "path": "beat.stats.output.elasticsearch.bulk_requests.completed",
+                              "type": "alias"
+                            }
+                          }
+                        },
+                        "indexers": {
+                          "properties": {
+                            "active": {
+                              "path": "beat.stats.output.elasticsearch.indexers.active",
+                              "type": "alias"
+                            },
+                            "created": {
+                              "path": "beat.stats.output.elasticsearch.indexers.created",
+                              "type": "alias"
+                            },
+                            "destroyed": {
+                              "path": "beat.stats.output.elasticsearch.indexers.destroyed",
+                              "type": "alias"
+                            }
+                          }
+                        }
+                      }
+                    },
                     "events": {
                       "properties": {
                         "acked": {

--- a/cmd/stats-to-mapping/testdata/golden/monitoring-beats.json
+++ b/cmd/stats-to-mapping/testdata/golden/monitoring-beats.json
@@ -465,6 +465,98 @@
                         }
                       }
                     },
+                    "jaeger": {
+                      "properties": {
+                        "grpc": {
+                          "properties": {
+                            "collect": {
+                              "properties": {
+                                "request": {
+                                  "properties": {
+                                    "count": {
+                                      "type": "long"
+                                    }
+                                  }
+                                },
+                                "response": {
+                                  "properties": {
+                                    "count": {
+                                      "type": "long"
+                                    },
+                                    "errors": {
+                                      "properties": {
+                                        "count": {
+                                          "type": "long"
+                                        },
+                                        "ratelimit": {
+                                          "type": "long"
+                                        },
+                                        "timeout": {
+                                          "type": "long"
+                                        },
+                                        "unauthorized": {
+                                          "type": "long"
+                                        }
+                                      }
+                                    },
+                                    "valid": {
+                                      "properties": {
+                                        "count": {
+                                          "type": "long"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "sampling": {
+                              "properties": {
+                                "event": {
+                                  "properties": {
+                                    "received": {
+                                      "properties": {
+                                        "count": {
+                                          "type": "long"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "request": {
+                                  "properties": {
+                                    "count": {
+                                      "type": "long"
+                                    }
+                                  }
+                                },
+                                "response": {
+                                  "properties": {
+                                    "count": {
+                                      "type": "long"
+                                    },
+                                    "errors": {
+                                      "properties": {
+                                        "count": {
+                                          "type": "long"
+                                        }
+                                      }
+                                    },
+                                    "valid": {
+                                      "properties": {
+                                        "count": {
+                                          "type": "long"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
                     "otlp": {
                       "properties": {
                         "grpc": {
@@ -1233,6 +1325,9 @@
                                 "closed": {
                                   "type": "long"
                                 },
+                                "concurrency": {
+                                  "type": "long"
+                                },
                                 "count": {
                                   "type": "long"
                                 },
@@ -1458,6 +1553,33 @@
                 },
                 "output": {
                   "properties": {
+                    "elasticsearch": {
+                      "properties": {
+                        "bulk_requests": {
+                          "properties": {
+                            "available": {
+                              "type": "long"
+                            },
+                            "completed": {
+                              "type": "long"
+                            }
+                          }
+                        },
+                        "indexers": {
+                          "properties": {
+                            "active": {
+                              "type": "long"
+                            },
+                            "created": {
+                              "type": "long"
+                            },
+                            "destroyed": {
+                              "type": "long"
+                            }
+                          }
+                        }
+                      }
+                    },
                     "events": {
                       "properties": {
                         "acked": {

--- a/cmd/stats-to-mapping/yamlfile.go
+++ b/cmd/stats-to-mapping/yamlfile.go
@@ -352,8 +352,17 @@ func (p *yamlEntryParser) parseFieldsAt(dashCol int) []item {
 			p.pos++
 			continue
 		}
-		if col != dashCol {
+		if col < dashCol {
+			// Shallower than this list's items; we've reached the end
+			// of the list (or popped past it).
 			return out
+		}
+		if col > dashCol {
+			// Deeper indent than any sibling at dashCol — folded-scalar
+			// continuation of a previous leaf's description, or some
+			// other content this parser doesn't model. Skip the line.
+			p.pos++
+			continue
 		}
 		rest := line[col:]
 		if !bytes.HasPrefix(rest, []byte("- name: ")) {
@@ -377,8 +386,17 @@ func (p *yamlEntryParser) parseEntry(dashCol int) item {
 			p.pos++
 			continue
 		}
-		if col != contCol {
+		if col < contCol {
+			// Shallower than the entry's own siblings — we're out of
+			// this entry. Don't consume the line.
 			break
+		}
+		if col > contCol {
+			// Deeper indent than the entry's mapping-pair lines:
+			// folded-scalar continuation of e.g. a description that
+			// this parser doesn't need to interpret. Skip the line.
+			p.pos++
+			continue
 		}
 		rest := line[col:]
 		switch {
@@ -392,9 +410,8 @@ func (p *yamlEntryParser) parseEntry(dashCol int) item {
 			p.pos++
 			it.Fields = p.parseFieldsAt(dashCol + 4)
 		default:
-			// Unknown line at sibling indent (e.g. metric_type:). Skip
-			// to stay forward-compatible with annotations renderItem
-			// emits but parseEntryFields doesn't itself need.
+			// Unknown line at sibling indent (e.g. metric_type:,
+			// description:, release:). Skip to stay forward-compatible.
 			p.pos++
 		}
 	}

--- a/cmd/stats-to-mapping/yamlfile.go
+++ b/cmd/stats-to-mapping/yamlfile.go
@@ -41,6 +41,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 // modifyBeatRoot updates metricbeat/module/beat/_meta/fields.yml.
@@ -186,7 +188,7 @@ func upsertYAML(path string, stats []byte, plan yamlPlan) error {
 			if plan.metricType == metricTypeRetain {
 				existingMetricTypes = extractMetricTypes(it.body)
 			}
-			existingFields = parseEntryFields(it.body, plan.childIndent)
+			existingFields = parseEntryFields(it.body)
 			break
 		}
 		merged := mergeFields(existingFields, fields)
@@ -308,194 +310,93 @@ func renderItem(buf *bytes.Buffer, it item, indent int, mt metricTypePolicy, ret
 	}
 }
 
-// parseEntryFields scans entry — the bytes of a single block-sequence
-// item written in the layout this tool emits — and returns the []item
-// tree for the entry's nested "fields:" list. baseDashCol is the
-// column of the entry's leading dash. Returns nil for leaf or alias
-// entries (no nested fields) and for groups whose fields list is
-// missing or empty.
+// yamlEntry mirrors the schema this tool reads on the upstream files
+// and writes back: each entry has a name, type, optional alias path,
+// optional fields list, and optional metric_type annotation. yaml.v3
+// handles every layout concern (indent, folded scalars, comments,
+// quoting variants) so this parser doesn't depend on the file's
+// formatting being any particular shape.
+type yamlEntry struct {
+	Name       string      `yaml:"name"`
+	Type       string      `yaml:"type"`
+	Path       string      `yaml:"path"`
+	Fields     []yamlEntry `yaml:"fields"`
+	MetricType string      `yaml:"metric_type"`
+}
+
+// parseEntryFields parses the bytes of a single block-sequence item
+// (the YAML chunk between two list-item dashes) and returns the
+// []item tree for that entry's nested "fields:" list. Returns nil for
+// leaf or alias entries (no nested fields) and on parse errors.
 //
-// Only handles the shape renderItem produces: each child entry begins
-// with "- name:" at column baseDashCol+4, followed by "type:" at +6
-// and either "fields:" (for groups), "path:" (for aliases), or
-// nothing else (for scalar leaves). metric_type lines are tolerated
-// and ignored — they're collected separately by extractMetricTypes.
-func parseEntryFields(entry []byte, baseDashCol int) []item {
-	lines := bytes.Split(entry, []byte{'\n'})
-	p := &yamlEntryParser{lines: lines}
-	// Skip past the entry's own "- name:" / "type: group" / "fields:"
-	// lines to position the parser at the first child entry.
-	for p.pos < len(p.lines) {
-		line := p.lines[p.pos]
-		p.pos++
-		if bytes.HasPrefix(bytes.TrimLeft(line, " "), []byte("fields:")) {
-			break
-		}
+// Goes through gopkg.in/yaml.v3, so the parse is robust against any
+// formatting the upstream files use — folded scalars, multi-line
+// strings, in-line comments, alternate quote styles — none of those
+// affect the result.
+func parseEntryFields(entry []byte) []item {
+	var seq []yamlEntry
+	if err := yaml.Unmarshal(entry, &seq); err != nil || len(seq) == 0 {
+		return nil
 	}
-	return p.parseFieldsAt(baseDashCol + 4)
+	return entriesToItems(seq[0].Fields)
 }
 
-// yamlEntryParser is a line-based parser for the YAML shape this tool
-// emits. It is intentionally narrow: it does not implement YAML, only
-// the strict layout renderItem produces.
-type yamlEntryParser struct {
-	lines [][]byte
-	pos   int
-}
-
-func (p *yamlEntryParser) parseFieldsAt(dashCol int) []item {
-	var out []item
-	for p.pos < len(p.lines) {
-		line := p.lines[p.pos]
-		col := leadingSpaces(line)
-		if col == len(line) {
-			p.pos++
+func entriesToItems(entries []yamlEntry) []item {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make([]item, 0, len(entries))
+	for _, e := range entries {
+		if e.Name == "" {
 			continue
 		}
-		if col < dashCol {
-			// Shallower than this list's items; we've reached the end
-			// of the list (or popped past it).
-			return out
-		}
-		if col > dashCol {
-			// Deeper indent than any sibling at dashCol — folded-scalar
-			// continuation of a previous leaf's description, or some
-			// other content this parser doesn't model. Skip the line.
-			p.pos++
-			continue
-		}
-		rest := line[col:]
-		if !bytes.HasPrefix(rest, []byte("- name: ")) {
-			return out
-		}
-		out = append(out, p.parseEntry(dashCol))
+		out = append(out, item{
+			Name:   e.Name,
+			Type:   e.Type,
+			Path:   e.Path,
+			Fields: entriesToItems(e.Fields),
+		})
 	}
 	return out
 }
 
-func (p *yamlEntryParser) parseEntry(dashCol int) item {
-	line := p.lines[p.pos]
-	name := unquoteYAMLScalar(strings.TrimSpace(string(line[dashCol+len("- name: "):])))
-	p.pos++
-	it := item{Name: name}
-	contCol := dashCol + 2
-	for p.pos < len(p.lines) {
-		line := p.lines[p.pos]
-		col := leadingSpaces(line)
-		if col == len(line) {
-			p.pos++
-			continue
-		}
-		if col < contCol {
-			// Shallower than the entry's own siblings — we're out of
-			// this entry. Don't consume the line.
-			break
-		}
-		if col > contCol {
-			// Deeper indent than the entry's mapping-pair lines:
-			// folded-scalar continuation of e.g. a description that
-			// this parser doesn't need to interpret. Skip the line.
-			p.pos++
-			continue
-		}
-		rest := line[col:]
-		switch {
-		case bytes.HasPrefix(rest, []byte("type: ")):
-			it.Type = strings.TrimSpace(string(rest[len("type: "):]))
-			p.pos++
-		case bytes.HasPrefix(rest, []byte("path: ")):
-			it.Path = strings.TrimSpace(string(rest[len("path: "):]))
-			p.pos++
-		case bytes.HasPrefix(rest, []byte("fields:")):
-			p.pos++
-			it.Fields = p.parseFieldsAt(dashCol + 4)
-		default:
-			// Unknown line at sibling indent (e.g. metric_type:,
-			// description:, release:). Skip to stay forward-compatible.
-			p.pos++
-		}
-	}
-	return it
-}
-
-func leadingSpaces(b []byte) int {
-	i := 0
-	for i < len(b) && b[i] == ' ' {
-		i++
-	}
-	return i
-}
-
-// extractMetricTypes scans entry — the bytes of a single block-sequence
-// item written in the same layout this tool emits — and returns a map of
-// dotted leaf path to metric_type value for every typed (non-group,
-// non-alias) leaf that carried a metric_type: annotation. Group and alias
-// entries are skipped because metric_type only applies to numeric leaves.
+// extractMetricTypes returns a map of dotted leaf path to metric_type
+// value for every typed (non-group, non-alias) leaf in entry that
+// carried a metric_type: annotation. Group and alias entries are
+// skipped because metric_type only applies to numeric leaves.
 //
-// The scanner relies on the file's strict 4-column-per-level indent and
-// "type:" / "metric_type:" siblings appearing at +2 from their owning
-// "- name:" line. It does not parse YAML in general; it only handles the
-// shape this tool itself produces.
+// Paths include the root entry's name as the leading component, to
+// match the fullPath renderItem builds when emitting the merged tree.
 func extractMetricTypes(entry []byte) map[string]string {
+	var seq []yamlEntry
+	if err := yaml.Unmarshal(entry, &seq); err != nil || len(seq) == 0 {
+		return nil
+	}
 	out := map[string]string{}
-	type frame struct {
-		name, ftype, metric string
-		dashCol             int
-	}
-	var stack []frame
+	collectMetricTypes(seq[0].Fields, seq[0].Name, out)
+	return out
+}
 
-	record := func(f frame) {
-		if f.ftype == "" || f.ftype == "group" || f.ftype == "alias" {
-			return
-		}
-		if f.metric == "" {
-			return
-		}
-		parts := make([]string, 0, len(stack)+1)
-		for _, p := range stack {
-			parts = append(parts, p.name)
-		}
-		parts = append(parts, f.name)
-		out[strings.Join(parts, ".")] = f.metric
-	}
-
-	closeTo := func(col int) {
-		for len(stack) > 0 && stack[len(stack)-1].dashCol >= col {
-			top := stack[len(stack)-1]
-			stack = stack[:len(stack)-1]
-			record(top)
-		}
-	}
-
-	for _, line := range bytes.Split(entry, []byte{'\n'}) {
-		s := string(line)
-		col := 0
-		for col < len(s) && s[col] == ' ' {
-			col++
-		}
-		if col == len(s) {
+func collectMetricTypes(entries []yamlEntry, prefix string, out map[string]string) {
+	for _, e := range entries {
+		if e.Name == "" {
 			continue
 		}
-		rest := s[col:]
-		switch {
-		case strings.HasPrefix(rest, "- name: "):
-			closeTo(col)
-			stack = append(stack, frame{
-				name:    unquoteYAMLScalar(strings.TrimSpace(rest[len("- name: "):])),
-				dashCol: col,
-			})
-		case strings.HasPrefix(rest, "type: "):
-			if n := len(stack); n > 0 {
-				stack[n-1].ftype = strings.TrimSpace(rest[len("type: "):])
-			}
-		case strings.HasPrefix(rest, "metric_type: "):
-			if n := len(stack); n > 0 {
-				stack[n-1].metric = strings.TrimSpace(rest[len("metric_type: "):])
-			}
+		path := e.Name
+		if prefix != "" {
+			path = prefix + "." + e.Name
+		}
+		if len(e.Fields) > 0 {
+			collectMetricTypes(e.Fields, path, out)
+			continue
+		}
+		if e.Type == "alias" {
+			continue
+		}
+		if e.MetricType != "" {
+			out[path] = e.MetricType
 		}
 	}
-	closeTo(0)
-	return out
 }
 
 // locateFieldsList walks plan.path through the document and returns the

--- a/cmd/stats-to-mapping/yamlfile.go
+++ b/cmd/stats-to-mapping/yamlfile.go
@@ -178,16 +178,20 @@ func upsertYAML(path string, stats []byte, plan yamlPlan) error {
 		// replaced and carry forward its metric_type annotations by
 		// dotted path. New fields get metric_type: FIXME.
 		var existingMetricTypes map[string]string
-		if plan.metricType == metricTypeRetain {
-			for _, it := range items {
-				if it.name == yamlName {
-					existingMetricTypes = extractMetricTypes(it.body)
-					break
-				}
+		var existingFields []item
+		for _, it := range items {
+			if it.name != yamlName {
+				continue
 			}
+			if plan.metricType == metricTypeRetain {
+				existingMetricTypes = extractMetricTypes(it.body)
+			}
+			existingFields = parseEntryFields(it.body, plan.childIndent)
+			break
 		}
+		merged := mergeFields(existingFields, fields)
 		var rendered bytes.Buffer
-		renderItem(&rendered, item{Name: yamlName, Type: "group", Fields: fields},
+		renderItem(&rendered, item{Name: yamlName, Type: "group", Fields: merged},
 			plan.childIndent, plan.metricType, existingMetricTypes, "")
 		items = upsertListItem(items, yamlName, rendered.Bytes())
 	}
@@ -302,6 +306,107 @@ func renderItem(buf *bytes.Buffer, it item, indent int, mt metricTypePolicy, ret
 			fmt.Fprintf(buf, "%smetric_type: %s\n", cont, value)
 		}
 	}
+}
+
+// parseEntryFields scans entry — the bytes of a single block-sequence
+// item written in the layout this tool emits — and returns the []item
+// tree for the entry's nested "fields:" list. baseDashCol is the
+// column of the entry's leading dash. Returns nil for leaf or alias
+// entries (no nested fields) and for groups whose fields list is
+// missing or empty.
+//
+// Only handles the shape renderItem produces: each child entry begins
+// with "- name:" at column baseDashCol+4, followed by "type:" at +6
+// and either "fields:" (for groups), "path:" (for aliases), or
+// nothing else (for scalar leaves). metric_type lines are tolerated
+// and ignored — they're collected separately by extractMetricTypes.
+func parseEntryFields(entry []byte, baseDashCol int) []item {
+	lines := bytes.Split(entry, []byte{'\n'})
+	p := &yamlEntryParser{lines: lines}
+	// Skip past the entry's own "- name:" / "type: group" / "fields:"
+	// lines to position the parser at the first child entry.
+	for p.pos < len(p.lines) {
+		line := p.lines[p.pos]
+		p.pos++
+		if bytes.HasPrefix(bytes.TrimLeft(line, " "), []byte("fields:")) {
+			break
+		}
+	}
+	return p.parseFieldsAt(baseDashCol + 4)
+}
+
+// yamlEntryParser is a line-based parser for the YAML shape this tool
+// emits. It is intentionally narrow: it does not implement YAML, only
+// the strict layout renderItem produces.
+type yamlEntryParser struct {
+	lines [][]byte
+	pos   int
+}
+
+func (p *yamlEntryParser) parseFieldsAt(dashCol int) []item {
+	var out []item
+	for p.pos < len(p.lines) {
+		line := p.lines[p.pos]
+		col := leadingSpaces(line)
+		if col == len(line) {
+			p.pos++
+			continue
+		}
+		if col != dashCol {
+			return out
+		}
+		rest := line[col:]
+		if !bytes.HasPrefix(rest, []byte("- name: ")) {
+			return out
+		}
+		out = append(out, p.parseEntry(dashCol))
+	}
+	return out
+}
+
+func (p *yamlEntryParser) parseEntry(dashCol int) item {
+	line := p.lines[p.pos]
+	name := unquoteYAMLScalar(strings.TrimSpace(string(line[dashCol+len("- name: "):])))
+	p.pos++
+	it := item{Name: name}
+	contCol := dashCol + 2
+	for p.pos < len(p.lines) {
+		line := p.lines[p.pos]
+		col := leadingSpaces(line)
+		if col == len(line) {
+			p.pos++
+			continue
+		}
+		if col != contCol {
+			break
+		}
+		rest := line[col:]
+		switch {
+		case bytes.HasPrefix(rest, []byte("type: ")):
+			it.Type = strings.TrimSpace(string(rest[len("type: "):]))
+			p.pos++
+		case bytes.HasPrefix(rest, []byte("path: ")):
+			it.Path = strings.TrimSpace(string(rest[len("path: "):]))
+			p.pos++
+		case bytes.HasPrefix(rest, []byte("fields:")):
+			p.pos++
+			it.Fields = p.parseFieldsAt(dashCol + 4)
+		default:
+			// Unknown line at sibling indent (e.g. metric_type:). Skip
+			// to stay forward-compatible with annotations renderItem
+			// emits but parseEntryFields doesn't itself need.
+			p.pos++
+		}
+	}
+	return it
+}
+
+func leadingSpaces(b []byte) int {
+	i := 0
+	for i < len(b) && b[i] == ' ' {
+		i++
+	}
+	return i
 }
 
 // extractMetricTypes scans entry — the bytes of a single block-sequence

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.40.0
 	go.opentelemetry.io/otel/sdk/metric v1.40.0
 	google.golang.org/grpc v1.79.2
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -41,7 +42,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260128011058-8636f8732409 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260128011058-8636f8732409 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 require (


### PR DESCRIPTION
## Summary

The first cut of \`stats-to-mapping\` replaced the \`apm-server\` and \`output\` subtrees of the upstream mapping files wholesale. apm-server's history of removed and renamed metrics — the Jaeger removal in [elastic/apm-server#14791](https://github.com/elastic/apm-server/pull/14791), the \`agentcfg.elasticsearch\` counter renames, etc. — means the upstream files have accumulated entries the current \`/stats\` no longer reports. A wholesale replace silently deletes those entries; downstream dashboards and queries that still reference the old field names break the next time the regen output is committed.

This PR switches the regen to a **deep merge** against the existing upstream subtree:

- entries that only exist upstream are kept,
- entries that only exist in \`/stats\` are added,
- entries that exist in both recurse if they're groups, and prefer the new entry's typing if they're leaves.

JSON merge runs on the parsed \`map[string]any\` of the existing \`parent[member].properties\` value before splicing the new bytes back. YAML merge parses the existing entry's body into a \`[]item\` tree (\`parseEntryFields\`) and feeds it through \`mergeFields\` alongside the new tree from \`/stats\`; \`renderItem\` emits the merged result. Existing upstream order is preserved; new entries append after.

## What changes in the goldens

The regen now keeps fields like \`agentcfg.elasticsearch.cache.entries.count\`, \`agentcfg.elasticsearch.fetch.{es,fallback,invalid,unavailable}\`, and the entire \`jaeger.grpc.collect.*\` subtree that the previous goldens had stripped. No fields are removed; the only \"deletion\" lines in the diff are reorderings (existing upstream entries keep their input position, so e.g. \`otlp.grpc.logs.response.errors.{count,ratelimit,timeout,unauthorized}\` retain their pre-merge order while new sibling errors like \`closed,decode,forbidden,…\` append after).

## Test plan

- [x] \`go test ./cmd/stats-to-mapping/...\` passes (existing golden tests + new \`TestMergeProperties\` / \`TestMergeFields\` unit tests).
- [ ] Reviewer spot-checks the diffs of the regenerated goldens to confirm they're additive (preserved upstream entries) and re-orderings only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)